### PR TITLE
Forbid changing the name, avatar or topic of a direct room

### DIFF
--- a/.circleci/merge_base_branch.sh
+++ b/.circleci/merge_base_branch.sh
@@ -17,7 +17,7 @@ then
     GITBASE="dinsic"
 else
     # Get the reference, using the GitHub API
-    GITBASE=`wget -O- https://api.github.com/repos/matrix-org/synapse/pulls/${CIRCLE_PR_NUMBER} | jq -r '.base.ref'`
+    GITBASE=`wget -O- https://api.github.com/repos/matrix-org/synapse-dinsic/pulls/${CIRCLE_PR_NUMBER} | jq -r '.base.ref'`
 fi
 
 # Show what we are before

--- a/changelog.d/1.feature
+++ b/changelog.d/1.feature
@@ -1,0 +1,1 @@
+Forbid changing the name, avatar or topic of a direct room.

--- a/scripts-dev/check-newsfragment
+++ b/scripts-dev/check-newsfragment
@@ -5,9 +5,9 @@
 
 set -e
 
-# make sure that origin/develop is up to date
-git remote set-branches --add origin develop
-git fetch origin develop
+# make sure that origin/dinsic is up to date
+git remote set-branches --add origin dinsic
+git fetch origin dinsic
 
 # if there are changes in the debian directory, check that the debian changelog
 # has been updated

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -237,6 +237,15 @@ class RoomAccessRules(object):
         if event.type == EventTypes.JoinRules:
             return self._on_join_rule_change(event, rule)
 
+        if event.type == EventTypes.RoomAvatar:
+            return self._on_room_avatar_change(event, rule)
+
+        if event.type == EventTypes.Name:
+            return self._on_room_name_change(event, rule)
+
+        if event.type == EventTypes.Topic:
+            return self._on_room_topic_change(event, rule)
+
         return True
 
     def _on_rules_change(self, event, state_events):
@@ -460,6 +469,47 @@ class RoomAccessRules(object):
             return rule == ACCESS_RULE_RESTRICTED
 
         return True
+
+    def _on_room_avatar_change(self, event, rule):
+        """Check whether a change of room avatar is allowed.
+        The current rule is to forbid such a change in direct chats but allow it
+        everywhere else.
+
+        Args:
+            event (synapse.events.EventBase): The event to check.
+            rule (str): The name of the rule to apply.
+        Returns:
+            bool, True if the event can be allowed, False otherwise.
+        """
+        return rule != ACCESS_RULE_DIRECT
+
+
+    def _on_room_name_change(self, event, rule):
+        """Check whether a change of room name is allowed.
+        The current rule is to forbid such a change in direct chats but allow it
+        everywhere else.
+
+        Args:
+            event (synapse.events.EventBase): The event to check.
+            rule (str): The name of the rule to apply.
+        Returns:
+            bool, True if the event can be allowed, False otherwise.
+        """
+        return rule != ACCESS_RULE_DIRECT
+
+
+    def _on_room_topic_change(self, event, rule):
+        """Check whether a change of room topic is allowed.
+        The current rule is to forbid such a change in direct chats but allow it
+        everywhere else.
+
+        Args:
+            event (synapse.events.EventBase): The event to check.
+            rule (str): The name of the rule to apply.
+        Returns:
+            bool, True if the event can be allowed, False otherwise.
+        """
+        return rule != ACCESS_RULE_DIRECT
 
     @staticmethod
     def _get_rule_from_state(state_events):

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -483,7 +483,6 @@ class RoomAccessRules(object):
         """
         return rule != ACCESS_RULE_DIRECT
 
-
     def _on_room_name_change(self, event, rule):
         """Check whether a change of room name is allowed.
         The current rule is to forbid such a change in direct chats but allow it
@@ -496,7 +495,6 @@ class RoomAccessRules(object):
             bool, True if the event can be allowed, False otherwise.
         """
         return rule != ACCESS_RULE_DIRECT
-
 
     def _on_room_topic_change(self, event, rule):
         """Check whether a change of room topic is allowed.

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -483,6 +483,111 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
             expected_code=403,
         )
 
+    def test_change_room_avatar(self):
+        """Tests that changing the room avatar is always allowed unless the room is a
+        direct chat, in which case it's forbidden.
+        """
+
+        avatar_content = {
+            "info": {
+                "h": 398,
+                "mimetype": "image/jpeg",
+                "size": 31037,
+                "w": 394
+            },
+            "url": "mxc://example.org/JWEIFJgwEIhweiWJE",
+        }
+
+        self.helper.send_state(
+            room_id=self.restricted_room,
+            event_type=EventTypes.RoomAvatar,
+            body=avatar_content,
+            tok=self.tok,
+            expect_code=200,
+        )
+
+        self.helper.send_state(
+            room_id=self.unrestricted_room,
+            event_type=EventTypes.RoomAvatar,
+            body=avatar_content,
+            tok=self.tok,
+            expect_code=200,
+        )
+
+        self.helper.send_state(
+            room_id=self.direct_rooms[0],
+            event_type=EventTypes.RoomAvatar,
+            body=avatar_content,
+            tok=self.tok,
+            expect_code=403,
+        )
+
+    def test_change_room_name(self):
+        """Tests that changing the room name is always allowed unless the room is a direct
+        chat, in which case it's forbidden.
+        """
+
+        name_content = {
+            "name": "My super room",
+        }
+
+        self.helper.send_state(
+            room_id=self.restricted_room,
+            event_type=EventTypes.Name,
+            body=name_content,
+            tok=self.tok,
+            expect_code=200,
+        )
+
+        self.helper.send_state(
+            room_id=self.unrestricted_room,
+            event_type=EventTypes.Name,
+            body=name_content,
+            tok=self.tok,
+            expect_code=200,
+        )
+
+        self.helper.send_state(
+            room_id=self.direct_rooms[0],
+            event_type=EventTypes.Name,
+            body=name_content,
+            tok=self.tok,
+            expect_code=403,
+        )
+
+    def test_change_room_topic(self):
+        """Tests that changing the room topic is always allowed unless the room is a
+        direct chat, in which case it's forbidden.
+        """
+
+        topic_content = {
+            "topic": "Welcome to this room",
+        }
+
+        self.helper.send_state(
+            room_id=self.restricted_room,
+            event_type=EventTypes.Topic,
+            body=topic_content,
+            tok=self.tok,
+            expect_code=200,
+        )
+
+        self.helper.send_state(
+            room_id=self.unrestricted_room,
+            event_type=EventTypes.Topic,
+            body=topic_content,
+            tok=self.tok,
+            expect_code=200,
+        )
+
+        self.helper.send_state(
+            room_id=self.direct_rooms[0],
+            event_type=EventTypes.Topic,
+            body=topic_content,
+            tok=self.tok,
+            expect_code=403,
+        )
+
     def create_room(
         self, direct=False, rule=None, preset=RoomCreationPreset.TRUSTED_PRIVATE_CHAT,
         initial_state=None, expected_code=200,

--- a/tox.ini
+++ b/tox.ini
@@ -128,7 +128,7 @@ commands = /bin/sh -c "isort -c -df -sp setup.cfg -rc synapse tests"
 skip_install = True
 deps = towncrier>=18.6.0rc1
 commands =
-   python -m towncrier.check --compare-with=origin/develop
+   python -m towncrier.check --compare-with=origin/dinsic
 basepython = python3.6
 
 [testenv:check-sampleconfig]


### PR DESCRIPTION
Forbids users from changing the name, avatar or topic of a room if the `im.vector.room.access_rule` state event is set to `direct`.