### PR TITLE
Don't treat 3PID revocation as a new 3PID invite

### DIFF
--- a/changelog.d/2.bugfix
+++ b/changelog.d/2.bugfix
@@ -1,0 +1,1 @@
+Don't treat 3PID revokation as a new 3PID invite.

--- a/changelog.d/2.bugfix
+++ b/changelog.d/2.bugfix
@@ -1,1 +1,1 @@
-Don't treat 3PID revokation as a new 3PID invite.
+Don't treat 3PID revocation as a new 3PID invite.

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -511,9 +511,9 @@ class RoomAccessRules(object):
         existing_members = []
         threepid_invite_tokens = []
         for key, state_event in state_events.items():
-            if key[0] == EventTypes.Member:
+            if key[0] == EventTypes.Member and state_event.content:
                 existing_members.append(state_event.state_key)
-            if key[0] == EventTypes.ThirdPartyInvite:
+            if key[0] == EventTypes.ThirdPartyInvite and state_event.content:
                 threepid_invite_tokens.append(state_event.state_key)
 
         # If the event is a state event, there already is an event with the same state key

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -575,7 +575,7 @@ class RoomAccessRules(object):
                 threepid_invite_tokens,
             )
 
-        return existing_members, len(threepid_invite_tokens)
+        return existing_members, list(threepid_invite_tokens)
 
     @staticmethod
     def _is_invite_from_threepid(invite, threepid_invite_token):

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -569,13 +569,13 @@ class RoomAccessRules(object):
         # room's state, in which case we need to remove the entry from the list in order
         # to avoid conflicts.
         if event.is_state():
-            def filter_out_event(state_key):
-                return event.state_key != state_key
+            existing_members = existing_members
+            threepid_invite_tokens = filter(
+                lambda sk: event.state_key != sk,
+                threepid_invite_tokens,
+            )
 
-            existing_members = filter(filter_out_event, existing_members)
-            threepid_invite_tokens = filter(filter_out_event, threepid_invite_tokens)
-
-        return list(existing_members), list(threepid_invite_tokens)
+        return existing_members, len(threepid_invite_tokens)
 
     @staticmethod
     def _is_invite_from_threepid(invite, threepid_invite_token):

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -483,6 +483,44 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
             expected_code=403,
         )
 
+    def test_revoke_3pid_invite_direct(self):
+        """Tests that revoking a 3PID invite doesn't cause the room access rules module to
+        confuse the revokation as a new 3PID invite.
+        """
+        invite_token = "sometoken"
+
+        invite_body = {
+            "display_name": "ker...@exa...",
+            "public_keys": [
+              {
+                "key_validity_url": "https://validity_url",
+                "public_key": "ta8IQ0u1sp44HVpxYi7dFOdS/bfwDjcy4xLFlfY5KOA"
+              },
+              {
+                "key_validity_url": "https://validity_url",
+                "public_key": "4_9nzEeDwR5N9s51jPodBiLnqH43A2_g2InVT137t9I"
+              }
+            ],
+            "key_validity_url": "https://validity_url",
+            "public_key": "ta8IQ0u1sp44HVpxYi7dFOdS/bfwDjcy4xLFlfY5KOA"
+        }
+
+        self.send_state_with_state_key(
+            room_id=self.direct_rooms[1],
+            event_type=EventTypes.ThirdPartyInvite,
+            state_key=invite_token,
+            body=invite_body,
+            tok=self.tok,
+        )
+
+        self.send_state_with_state_key(
+            room_id=self.direct_rooms[1],
+            event_type=EventTypes.ThirdPartyInvite,
+            state_key=invite_token,
+            body={},
+            tok=self.tok,
+        )
+
     def create_room(
         self, direct=False, rule=None, preset=RoomCreationPreset.TRUSTED_PRIVATE_CHAT,
         initial_state=None, expected_code=200,
@@ -574,3 +612,20 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         )
         self.render(request)
         self.assertEqual(channel.code, expected_code, channel.result)
+
+    def send_state_with_state_key(
+        self, room_id, event_type, state_key, body, tok, expect_code=200
+    ):
+        path = "/_matrix/client/r0/rooms/%s/state/%s/%s" % (
+            room_id, event_type, state_key
+        )
+
+        request, channel = self.make_request(
+            "PUT", path, json.dumps(body), access_token=tok
+        )
+        self.render(request)
+
+        self.assertEqual(channel.code, expect_code, channel.result)
+
+        return channel.json_body
+

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -586,6 +586,7 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
             body=topic_content,
             tok=self.tok,
             expect_code=403,
+        )
 
     def test_revoke_3pid_invite_direct(self):
         """Tests that revoking a 3PID invite doesn't cause the room access rules module to

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -743,4 +743,3 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         self.assertEqual(channel.code, expect_code, channel.result)
 
         return channel.json_body
-

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -521,6 +521,16 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
             tok=self.tok,
         )
 
+        invite_token = "someothertoken"
+
+        self.send_state_with_state_key(
+            room_id=self.direct_rooms[1],
+            event_type=EventTypes.ThirdPartyInvite,
+            state_key=invite_token,
+            body=invite_body,
+            tok=self.tok,
+        )
+
     def create_room(
         self, direct=False, rule=None, preset=RoomCreationPreset.TRUSTED_PRIVATE_CHAT,
         initial_state=None, expected_code=200,


### PR DESCRIPTION
This bug was causing revokations of 3PID invites as new invites.

This PR solves this by filtering out the current event from the list of 3PID invite tokens.

This PR also makes it so revoked 3PID invites are excluded from the 3PID invite count.