### PR TITLE
Ensure the password reset template is correctly converted to binary

### DIFF
--- a/changelog.d/3.bugfix
+++ b/changelog.d/3.bugfix
@@ -1,0 +1,1 @@
+Fix encoding on password reset HTML responses in Python 2.

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -16,7 +16,7 @@
 import argparse
 import errno
 import os
-from io import open
+from io import open as io_open
 from textwrap import dedent
 
 from six import integer_types
@@ -132,7 +132,7 @@ class Config(object):
     @classmethod
     def read_file(cls, file_path, config_name):
         cls.check_file(file_path, config_name)
-        with open(file_path, encoding="utf-8") as file_stream:
+        with io_open(file_path, encoding="utf-8") as file_stream:
             return file_stream.read()
 
     @staticmethod

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -15,6 +15,7 @@
 
 import argparse
 import errno
+from io import open
 import os
 from textwrap import dedent
 
@@ -131,7 +132,7 @@ class Config(object):
     @classmethod
     def read_file(cls, file_path, config_name):
         cls.check_file(file_path, config_name)
-        with open(file_path) as file_stream:
+        with open(file_path, encoding="utf-8") as file_stream:
             return file_stream.read()
 
     @staticmethod

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -15,8 +15,8 @@
 
 import argparse
 import errno
-from io import open
 import os
+from io import open
 from textwrap import dedent
 
 from six import integer_types

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -67,7 +67,7 @@ REQUIREMENTS = [
     "pymacaroons>=0.13.0",
     "msgpack>=0.5.0",
     "phonenumbers>=8.2.0",
-    "six>=1.12",
+    "six>=1.10",
     # prometheus_client 0.4.0 changed the format of counter metrics
     # (cf https://github.com/matrix-org/synapse/issues/4001)
     "prometheus_client>=0.0.18,<0.4.0",

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -17,7 +17,6 @@
 import logging
 import re
 
-from six import ensure_binary
 from six.moves import http_client
 
 import jinja2
@@ -296,7 +295,7 @@ class PasswordResetSubmitTokenServlet(RestServlet):
             )
             request.setResponseCode(e.code)
 
-        request.write(ensure_binary(html))
+        request.write(html.encode('utf-8'))
         finish_request(request)
         defer.returnValue(None)
 

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -17,6 +17,7 @@
 import logging
 import re
 
+from six import ensure_binary
 from six.moves import http_client
 
 import jinja2
@@ -295,7 +296,7 @@ class PasswordResetSubmitTokenServlet(RestServlet):
             )
             request.setResponseCode(e.code)
 
-        request.write(html.encode('utf-8'))
+        request.write(ensure_binary(html))
         finish_request(request)
         defer.returnValue(None)
 

--- a/synapse/rest/client/v2_alpha/account_validity.py
+++ b/synapse/rest/client/v2_alpha/account_validity.py
@@ -15,8 +15,6 @@
 
 import logging
 
-from six import ensure_binary
-
 from twisted.internet import defer
 
 from synapse.api.errors import AuthError, SynapseError
@@ -65,7 +63,7 @@ class AccountValidityRenewServlet(RestServlet):
         request.setResponseCode(status_code)
         request.setHeader(b"Content-Type", b"text/html; charset=utf-8")
         request.setHeader(b"Content-Length", b"%d" % (len(response),))
-        request.write(ensure_binary(response))
+        request.write(response.encode("utf8"))
         finish_request(request)
         defer.returnValue(None)
 

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -20,7 +20,6 @@ import json
 import os
 
 from mock import Mock
-from six import ensure_binary
 
 import pkg_resources
 
@@ -438,7 +437,7 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
         # Check that the HTML we're getting is the one we expect on a successful renewal.
         expected_html = self.hs.config.account_validity.account_renewed_html_content
         self.assertEqual(
-            channel.result["body"], ensure_binary(expected_html), channel.result
+            channel.result["body"], expected_html.encode("utf8"), channel.result
         )
 
         # Move 3 days forward. If the renewal failed, every authed request with
@@ -468,7 +467,7 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
         # invalid/unknown token.
         expected_html = self.hs.config.account_validity.invalid_token_html_content
         self.assertEqual(
-            channel.result["body"], ensure_binary(expected_html), channel.result
+            channel.result["body"], expected_html.encode("utf8"), channel.result
         )
 
     def test_manual_email_send(self):


### PR DESCRIPTION
Python 2 seems to choke when trying to convert a file's content to bytes if that content includes special characters. This looks like it's because `.read()` on a file descriptor returns a `str` instead of a `unicode` on Python 2, which makes `content.encode("utf8")` fail because it doesn't expect a special char.

Python 2:

```
Python 2.7.16 (default, Mar 11 2019, 18:59:25) 
[GCC 8.2.1 20181127] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> f = open("/home/brendan/Documents/matrix/synapse/synapse/res/templates/account_validity_renewal_success.html")
>>> s = f.read()
>>> type(s)
<type 'str'>
>>> s.encode("utf8")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 536: ordinal not in range(128)
```

Python 3:

```
Python 3.7.4 (default, Jul 16 2019, 07:12:58) 
[GCC 9.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> f = open("/home/brendan/Documents/matrix/synapse/synapse/res/templates/account_validity_renewal_success.html")
>>> s = f.read()
>>> type(s)
<class 'str'>
>>> s.encode("utf8")
b'<!DOCTYPE html>\n<html lang="fr-FR">\n<head>\n  <meta charset="utf-8"/>\n  <meta http-equiv="Cache-control" content="no-cache">\n\n  <style type="text/css">\n    body {\n      font-family: Helvetica, Arial, Sans-Serif;\n    }\n    #head {\n      font-size:32px;\n      text-align:center;\n    }\n    #msg {\n      margin-top: 20px;\n      font-size: 25px;\n      text-align: center;\n    }\n  </style>\n\n</head>\n<body>\n<div id="head">\n  <img id="logo" src="/images/tchap192.png" width="192" height="192" alt="Tchap" />\n</div>\n\n<div id="msg">Votre compte a \xc3\xa9t\xc3\xa9 renouvel\xc3\xa9 avec succ\xc3\xa8s.</div>\n</body>\n</html>\n'
```

This would cause Synapse to respond with a 500 error to any client trying to query one of the affected endpoints if the HTML to serve contains special characters (e.g. french translation of the existing files).

six's `ensure_binary` function ensures that what we try to send to the client is of the right type (which is `str` on Python 2 and `bytes` on Python 3). FWIW, it's already used, working and tested on this fork since https://github.com/matrix-org/synapse/pull/5932.