### PR TITLE
Fix handling of filtered strings in Python 3 when processing MXIDs

### DIFF
--- a/changelog.d/4.bugfix
+++ b/changelog.d/4.bugfix
@@ -1,0 +1,1 @@
+Fix handling of filtered strings in Python 3.

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -17,6 +17,7 @@ import string
 from collections import namedtuple
 
 import attr
+from six.moves import filter
 
 from synapse.api.errors import SynapseError
 
@@ -240,7 +241,8 @@ def strip_invalid_mxid_characters(localpart):
     Returns:
         localpart (basestring): the localpart having been stripped
     """
-    return filter(lambda c: c in mxid_localpart_allowed_characters, localpart)
+    filtered = filter(lambda c: c in mxid_localpart_allowed_characters, localpart)
+    return "".join(list(filtered))
 
 
 UPPER_CASE_PATTERN = re.compile(b"[A-Z_]")

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -16,8 +16,9 @@ import re
 import string
 from collections import namedtuple
 
-import attr
 from six.moves import filter
+
+import attr
 
 from synapse.api.errors import SynapseError
 

--- a/synapse/types.py
+++ b/synapse/types.py
@@ -243,7 +243,7 @@ def strip_invalid_mxid_characters(localpart):
         localpart (basestring): the localpart having been stripped
     """
     filtered = filter(lambda c: c in mxid_localpart_allowed_characters, localpart)
-    return "".join(list(filtered))
+    return "".join(filtered)
 
 
 UPPER_CASE_PATTERN = re.compile(b"[A-Z_]")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -12,9 +12,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from six import string_types
 
 from synapse.api.errors import SynapseError
-from synapse.types import GroupID, RoomAlias, UserID, map_username_to_mxid_localpart
+from synapse.types import (
+    GroupID,
+    RoomAlias,
+    UserID,
+    map_username_to_mxid_localpart,
+    strip_invalid_mxid_characters,
+)
 
 from tests import unittest
 from tests.utils import TestHomeServer
@@ -106,3 +113,16 @@ class MapUsernameTestCase(unittest.TestCase):
         self.assertEqual(
             map_username_to_mxid_localpart(u'têst'.encode('utf-8')), "t=c3=aast"
         )
+
+
+class StripInvalidMxidCharactersTestCase(unittest.TestCase):
+    def test_return_type(self):
+        unstripped = strip_invalid_mxid_characters("test")
+        stripped = strip_invalid_mxid_characters("test@")
+
+        self.assertTrue(isinstance(unstripped, string_types), type(unstripped))
+        self.assertTrue(isinstance(stripped, string_types), type(stripped))
+
+    def test_strip(self):
+        stripped = strip_invalid_mxid_characters("test@")
+        self.assertEqual(stripped, "test", stripped)


### PR DESCRIPTION
Python 2's `filter()` function and Python 3's don't return the same type when processing a string (respectively `str` and `filter`), therefore registration fails on Python 3 because it tries to process the return value of `strip_invalid_mxid_characters` as a string.

This PR makes `strip_invalid_mxid_characters` use six's compatibility mapping (which resolves to `itertools.ifilter()` if using Python2, and `filter()` if using Python 3, which have the same behaviour), then generate a string from the filtered list, in order to ensure consistent behaviour between Python 2 and Python 3.

Another solution would have been to add something like:

```python
if isinstance(filtered, six.string_types):
    return filtered
else:
    return "".join(list(filtered))
```

But it looks a bit more hacky to me.