### PR TITLE
Fix room retention policy management in worker mode

### DIFF
--- a/changelog.d/5.bugfix
+++ b/changelog.d/5.bugfix
@@ -1,1 +1,1 @@
-Fix room retention policy management for in worker mode.
+Fix room retention policy management in worker mode.

--- a/changelog.d/5.bugfix
+++ b/changelog.d/5.bugfix
@@ -1,0 +1,1 @@
+Fix room retention policy management for in worker mode.

--- a/synapse/storage/room.py
+++ b/synapse/storage/room.py
@@ -238,6 +238,14 @@ class RoomWorkerStore(SQLBaseStore):
         Returns:
             dict[int, int]: "min_lifetime" and "max_lifetime" for this room.
         """
+        # If the room retention feature is disabled, return a policy with no minimum nor
+        # maximum, in order not to filter out events we should filter out when sending to
+        # the client.
+        if not self.config.retention_enabled:
+            defer.returnValue({
+                "min_lifetime": None,
+                "max_lifetime": None,
+            })
 
         def get_retention_policy_for_room_txn(txn):
             txn.execute(


### PR DESCRIPTION
Synchotron workers happen to error because of this because `synapse.visibility.filter_events_for_client` calls a `get_retention_policy_for_room` storage function which doesn't exist in the `RoomWorkerStore`. This PR moves that function from `RoomStore` to `RoomWorkerStore`.

It also adds a condition at the beginning of the function that makes it return a null retention policy for every room if the feature is disabled in the server's configuration. This is to prevent `synapse.visibility.filter_events_for_client` from filtering out events due to a room's retention policy when the feature's not on (e.g. if it has been turned on for some time but then turned off).