### PR TITLE
Allow membership events which membership isn't join or invite in restricted rooms

### DIFF
--- a/changelog.d/6.bugfix
+++ b/changelog.d/6.bugfix
@@ -1,0 +1,1 @@
+Don't forbid membership events which membership isn't 'join' or 'invite' in restricted rooms, so that users who got into these rooms before the access rules started to be enforced can leave them.


### PR DESCRIPTION
Otherwise, users who got into restricted rooms before the room access rules started being enforced aren't able to leave them.