### PR TITLE
Don't apply retention policy based filtering on state events

### DIFF
--- a/changelog.d/10.bugfix
+++ b/changelog.d/10.bugfix
@@ -1,0 +1,1 @@
+Don't apply retention policy based filtering on state events.


### PR DESCRIPTION
As per MSC1763, "Retention is only considered for non-state events", so don't filter out state events based on the room's retention policy.