### PR TITLE
Create configurable ratelimiter for 3pid invites

### DIFF
--- a/changelog.d/11.feature
+++ b/changelog.d/11.feature
@@ -1,0 +1,1 @@
+Allow server admins to configure a custom global rate-limiting for third party invites.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -568,7 +568,7 @@ log_config: "CONFDIR/SERVERNAME.log.config"
 #   - one for login that ratelimits login requests based on the account the
 #     client is attempting to log into, based on the amount of failed login
 #     attempts for this account.
-#   - one that ratelimits third-party invites requests based on the account the
+#   - one that ratelimits third-party invites requests based on the account
 #     that's making the requests.
 #
 # The defaults are as shown below.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -568,6 +568,8 @@ log_config: "CONFDIR/SERVERNAME.log.config"
 #   - one for login that ratelimits login requests based on the account the
 #     client is attempting to log into, based on the amount of failed login
 #     attempts for this account.
+#   - one that ratelimits third-party invites requests based on the account the
+#     that's making the requests.
 #
 # The defaults are as shown below.
 #
@@ -589,6 +591,10 @@ log_config: "CONFDIR/SERVERNAME.log.config"
 #  failed_attempts:
 #    per_second: 0.17
 #    burst_count: 3
+#
+#rc_third_party_invite:
+#  per_second: 0.2
+#  burst_count: 10
 
 
 # Ratelimiting settings for incoming federation

--- a/scripts/generate_signing_key.py
+++ b/scripts/generate_signing_key.py
@@ -16,7 +16,7 @@
 import argparse
 import sys
 
-from signedjson.key import generate_signing_key, write_signing_keys
+from signedjson.key import write_signing_keys, generate_signing_key
 
 from synapse.util.stringutils import random_string
 

--- a/scripts/generate_signing_key.py
+++ b/scripts/generate_signing_key.py
@@ -16,7 +16,7 @@
 import argparse
 import sys
 
-from signedjson.key import write_signing_keys, generate_signing_key
+from signedjson.key import generate_signing_key, write_signing_keys
 
 from synapse.util.stringutils import random_string
 

--- a/synapse/config/ratelimiting.py
+++ b/synapse/config/ratelimiting.py
@@ -68,7 +68,9 @@ class RatelimitConfig(Config):
             )
 
         self.rc_registration = RateLimitConfig(config.get("rc_registration", {}))
-        self.rc_third_party_invite = RateLimitConfig(config.get("rc_third_party_invite", {}))
+        self.rc_third_party_invite = RateLimitConfig(
+            config.get("rc_third_party_invite", {})
+        )
 
         rc_login_config = config.get("rc_login", {})
         self.rc_login_address = RateLimitConfig(rc_login_config.get("address", {}))

--- a/synapse/config/ratelimiting.py
+++ b/synapse/config/ratelimiting.py
@@ -105,7 +105,7 @@ class RatelimitConfig(Config):
         #   - one for login that ratelimits login requests based on the account the
         #     client is attempting to log into, based on the amount of failed login
         #     attempts for this account.
-        #   - one that ratelimits third-party invites requests based on the account the
+        #   - one that ratelimits third-party invites requests based on the account
         #     that's making the requests.
         #
         # The defaults are as shown below.

--- a/synapse/config/ratelimiting.py
+++ b/synapse/config/ratelimiting.py
@@ -68,6 +68,7 @@ class RatelimitConfig(Config):
             )
 
         self.rc_registration = RateLimitConfig(config.get("rc_registration", {}))
+        self.rc_third_party_invite = RateLimitConfig(config.get("rc_third_party_invite", {}))
 
         rc_login_config = config.get("rc_login", {})
         self.rc_login_address = RateLimitConfig(rc_login_config.get("address", {}))
@@ -102,6 +103,8 @@ class RatelimitConfig(Config):
         #   - one for login that ratelimits login requests based on the account the
         #     client is attempting to log into, based on the amount of failed login
         #     attempts for this account.
+        #   - one that ratelimits third-party invites requests based on the account the
+        #     that's making the requests.
         #
         # The defaults are as shown below.
         #
@@ -123,6 +126,10 @@ class RatelimitConfig(Config):
         #  failed_attempts:
         #    per_second: 0.17
         #    burst_count: 3
+        #
+        #rc_third_party_invite:
+        #  per_second: 0.2
+        #  burst_count: 10
 
 
         # Ratelimiting settings for incoming federation

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -29,6 +29,7 @@ from synapse.api.errors import AuthError, Codes, ProxiedRequestError, SynapseErr
 from synapse.types import RoomID, UserID
 from synapse.util.async_helpers import Linearizer
 from synapse.util.distributor import user_joined_room, user_left_room
+from synapse.api.ratelimiting import Ratelimiter
 
 from ._base import BaseHandler
 
@@ -74,11 +75,7 @@ class RoomMemberHandler(object):
         self.rewrite_identity_server_urls = self.config.rewrite_identity_server_urls
         self._enable_lookup = hs.config.enable_3pid_lookup
         self.allow_per_room_profiles = self.config.allow_per_room_profiles
-
-        # This is only used to get at ratelimit function, and
-        # maybe_kick_guest_users. It's fine there are multiple of these as
-        # it doesn't store state.
-        self.base_handler = BaseHandler(hs)
+        self.ratelimiter = Ratelimiter()
 
     @abc.abstractmethod
     def _remote_join(self, requester, remote_room_hosts, room_id, user, content):
@@ -773,7 +770,12 @@ class RoomMemberHandler(object):
 
         # We need to rate limit *before* we send out any 3PID invites, so we
         # can't just rely on the standard ratelimiting of events.
-        yield self.base_handler.ratelimit(requester)
+        self.ratelimiter.ratelimit(
+            requester.user.to_string(), time_now_s=self.hs.clock.time(),
+            rate_hz=self.hs.config.rc_third_party_invite.per_second,
+            burst_count=self.hs.config.rc_third_party_invite.burst_count,
+            update=True,
+        )
 
         can_invite = yield self.third_party_event_rules.check_threepid_can_be_invited(
             medium, address, room_id,

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -26,12 +26,10 @@ import synapse.server
 import synapse.types
 from synapse.api.constants import EventTypes, Membership
 from synapse.api.errors import AuthError, Codes, ProxiedRequestError, SynapseError
+from synapse.api.ratelimiting import Ratelimiter
 from synapse.types import RoomID, UserID
 from synapse.util.async_helpers import Linearizer
 from synapse.util.distributor import user_joined_room, user_left_room
-from synapse.api.ratelimiting import Ratelimiter
-
-from ._base import BaseHandler
 
 logger = logging.getLogger(__name__)
 

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -327,6 +327,8 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         )
 
         # Disable the 3pid invite ratelimiter
+        burst = self.hs.config.rc_third_party_invite.burst_count
+        per_second = self.hs.config.rc_third_party_invite.per_second
         self.hs.config.rc_third_party_invite.burst_count = 10
         self.hs.config.rc_third_party_invite.per_second = 0.1
 
@@ -357,6 +359,9 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
             room_id=self.direct_rooms[2],
             expected_code=403,
         )
+
+        self.hs.config.rc_third_party_invite.burst_count = burst
+        self.hs.config.rc_third_party_invite.per_second = per_second
 
     def test_unrestricted(self):
         """Tests that, in unrestricted mode, we can invite whoever we want, but we can

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -326,6 +326,10 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
             expect_code=200,
         )
 
+        # Disable the 3pid invite ratelimiter
+        self.hs.config.rc_third_party_invite.burst_count = 10
+        self.hs.config.rc_third_party_invite.per_second = 0.1
+
         # We can't send a 3PID invite to a room that already has two members.
         self.send_threepid_invite(
             address="test@allowed_domain",


### PR DESCRIPTION
Create a configurable rate-limiter for 3pid invites. 3pid invites already had a rate limiter, but it was locked to the per-user message rate limit. This changes it to that they are rate-limited based on a global option in `homeserver.yaml`.

This prevents per-user ratelimit overrides from affecting 3pid invites, but I don't think that would be a surprise to new users. I would find it odd if anyone was already relying on that behaviour, but if they are the changelog should make this change clear regardless.

Sytest PR https://github.com/matrix-org/sytest/pull/740