### PR TITLE
Add a /user/:user_id/info servlet to give user deactivated/expired information

### DIFF
--- a/changelog.d/12.feature
+++ b/changelog.d/12.feature
@@ -1,0 +1,1 @@
+Add `/user/:user_id/info` CS servlet and to give user deactivated/expired information.

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -344,13 +344,8 @@ class SQLBaseStore(object):
         self._simple_upsert_txn(
             txn,
             "account_validity",
-            keyvalues={
-                "user_id": user_id,
-            },
-            values={
-                "expiration_ts_ms": expiration_ts,
-                "email_sent": False,
-            },
+            keyvalues={"user_id": user_id, },
+            values={"expiration_ts_ms": expiration_ts, "email_sent": False, },
         )
 
     def start_profiling(self):

--- a/synapse/storage/_base.py
+++ b/synapse/storage/_base.py
@@ -341,11 +341,13 @@ class SQLBaseStore(object):
                 expiration_ts,
             )
 
-        self._simple_insert_txn(
+        self._simple_upsert_txn(
             txn,
             "account_validity",
-            values={
+            keyvalues={
                 "user_id": user_id,
+            },
+            values={
                 "expiration_ts_ms": expiration_ts,
                 "email_sent": False,
             },


### PR DESCRIPTION
Provides an endpoint `/client/r0/user/{user_id}/info` that responds with the following JSON body to authenticated users:

```
{
  "deactivated": false|true,
  "expired": false|true
}
```

Sytest PR: https://github.com/matrix-org/sytest/pull/741

TODO:
  - [x] Federation endpoint