### PR TITLE
Capatilise letters after a - in new user displaynames

### DIFF
--- a/changelog.d/14.feature
+++ b/changelog.d/14.feature
@@ -1,0 +1,1 @@
+User displaynames now have capitalied letters after - symbols.

--- a/changelog.d/14.feature
+++ b/changelog.d/14.feature
@@ -1,1 +1,1 @@
-User displaynames now have capitalied letters after - symbols.
+User displaynames now have capitalised letters after - symbols.

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -738,18 +738,18 @@ def cap(s):
     # Split phrase by spaces and hyphens
     # We will end up with a list of lists, where strings in each sublist must be
     # joined by hyphens
-    # e.g 'jean-philippe person' -> [['jean', 'philippe'], ['person']]
+    # e.g 'jack-phill person' -> [['jack', 'phill'], ['person']]
     s = [x.split("-") for x in s.split()]
 
     # Capitalise each word in each sublist
-    # [['jean', 'philippe'], ['person']] -> [['Jean', 'Philippe'], ['Person']]
+    # [['jack', 'phill'], ['person']] -> [['Jack', 'Phill'], ['Person']]
     for i in range(len(s)):
         inner_list = s[i]
         for j in range(len(inner_list)):
             s[i][j] = s[i][j].capitalize()
 
     # Join each inner list with hyphens and each outer list by spaces
-    # [['Jean', 'Philippe'], ['Person']] -> 'Jean-Philippe Person'
+    # [['Jack', 'Phill'], ['Person']] -> 'Jack-Phill Person'
     return ' '.join(['-'.join(x) for x in s])
 
 

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -19,7 +19,6 @@ import hmac
 import logging
 import re
 from hashlib import sha1
-from string import capwords
 
 from six import string_types
 
@@ -486,21 +485,8 @@ class RegisterRestServlet(RestServlet):
                     if self.hs.config.register_just_use_email_for_display_name:
                         desired_display_name = address
                     else:
-                        # XXX: a nasty heuristic to turn an email address into
-                        # a displayname, as part of register_mxid_from_3pid
-                        parts = address.replace('.', ' ').split('@')
-                        org_parts = parts[1].split(' ')
-
-                        if org_parts[-2] == "matrix" and org_parts[-1] == "org":
-                            org = "Tchap Admin"
-                        elif org_parts[-2] == "gouv" and org_parts[-1] == "fr":
-                            org = org_parts[-3] if len(org_parts) > 2 else org_parts[-2]
-                        else:
-                            org = org_parts[-2]
-
-                        desired_display_name = (
-                            capwords(parts[0]) + " [" + capwords(org) + "]"
-                        )
+                        # Custom mapping between email address and display name
+                        desired_display_name = self._map_email_to_displayname(address)
                 elif (
                     self.hs.config.register_mxid_from_3pid == 'msisdn' and
                     LoginType.MSISDN in auth_result
@@ -741,6 +727,62 @@ class RegisterRestServlet(RestServlet):
             "access_token": access_token,
             "home_server": self.hs.hostname,
         }))
+
+
+def _map_email_to_displayname(address):
+    """Custom mapping from an email address to a user displayname
+
+    Args:
+        address (str): The email address to process
+    Returns:
+        str: The new displayname
+    """
+    # Split the part before and after the @ in the email.
+    # Replace all . with spaces in the first part
+    parts = address.replace('.', ' ').split('@')
+
+    # Figure out which org this email address belongs to
+    org_parts = parts[1].split(' ')
+
+    # If this is a ...matrix.org email, mark them as an Admin
+    if org_parts[-2] == "matrix" and org_parts[-1] == "org":
+        org = "Tchap Admin"
+
+    # Is this is a ...gouv.fr address, set the org to whatever is before
+    # gouv.fr. If there isn't anything (a @gouv.fr email) simply mark their
+    # org as "gouv"
+    elif org_parts[-2] == "gouv" and org_parts[-1] == "fr":
+        org = org_parts[-3] if len(org_parts) > 2 else org_parts[-2]
+
+    # Otherwise, mark their org as the email's second-level domain name
+    else:
+        org = org_parts[-2]
+
+    def cap(s):
+        """Capitalise words in a string, including examples such as
+        'John-Doe'"""
+        if not s:
+            return s
+
+        # Convert str to a list so that we can edit each character
+        s = list(s)
+
+        # Capatilise the first letter
+        s[0] = s[0].capitalize()
+
+        s_len = len(s)
+        for i in range(s_len):
+            if (s[i] == " " or s[i] == "-") and i < s_len - 1:
+                s[i + 1] = s[i + 1].capitalize()
+
+        # Convert list back to a str
+        return ''.join(s)
+
+    desired_display_name = (
+        cap(parts[0]) + " [" + cap(org) + "]"
+    )
+
+    return desired_display_name
 
 
 def register_servlets(hs, http_server):

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -18,6 +18,7 @@
 import hmac
 import logging
 import re
+import string
 from hashlib import sha1
 
 from six import string_types
@@ -729,6 +730,30 @@ class RegisterRestServlet(RestServlet):
         }))
 
 
+def cap(s):
+    """Capitalise words in a string, including examples such as
+    'John-Doe'"""
+    if not s:
+        return s
+
+    # Split phrase by spaces and hyphens
+    # We will end up with a list of lists, where strings in each sublist must be
+    # joined by hyphens
+    # e.g 'jean-philippe person' -> [['jean', 'philippe'], ['person']]
+    s = [x.split("-") for x in s.split()]
+
+    # Capitalise each word in each sublist
+    # [['jean', 'philippe'], ['person']] -> [['Jean', 'Philippe'], ['Person']]
+    for i in range(len(s)):
+        inner_list = s[i]
+        for j in range(len(inner_list)):
+            s[i][j] = s[i][j].capitalize()
+
+    # Join each inner list with hyphens and each outer list by spaces
+    # [['Jean', 'Philippe'], ['Person']] -> 'Jean-Philippe Person'
+    return ' '.join(['-'.join(x) for x in s])
+
+
 def _map_email_to_displayname(address):
     """Custom mapping from an email address to a user displayname
 
@@ -757,26 +782,6 @@ def _map_email_to_displayname(address):
     # Otherwise, mark their org as the email's second-level domain name
     else:
         org = org_parts[-2]
-
-    def cap(s):
-        """Capitalise words in a string, including examples such as
-        'John-Doe'"""
-        if not s:
-            return s
-
-        # Convert str to a list so that we can edit each character
-        s = list(s)
-
-        # Capatilise the first letter
-        s[0] = s[0].capitalize()
-
-        s_len = len(s)
-        for i in range(s_len):
-            if (s[i] == " " or s[i] == "-") and i < s_len - 1:
-                s[i + 1] = s[i + 1].capitalize()
-
-        # Convert list back to a str
-        return ''.join(s)
 
     desired_display_name = (
         cap(parts[0]) + " [" + cap(org) + "]"

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -18,7 +18,6 @@
 import hmac
 import logging
 import re
-import string
 from hashlib import sha1
 
 from six import string_types

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -729,29 +729,24 @@ class RegisterRestServlet(RestServlet):
         }))
 
 
-def cap(s):
-    """Capitalise words in a string, including examples such as
-    'John-Doe'
+def cap(name):
+    """Capitalise parts of a name containing different words, including those
+    separated by hyphens.
+    For example, 'John-Doe'
+
+    Args:
+        name (str): The name to parse
     """
-    if not s:
-        return s
+    if not name:
+        return name
 
-    # Split phrase by spaces and hyphens
-    # We will end up with a list of lists, where strings in each sublist must be
-    # joined by hyphens
-    # e.g 'jack-phill person' -> [['jack', 'phill'], ['person']]
-    s = [x.split("-") for x in s.split()]
-
-    # Capitalise each word in each sublist
-    # [['jack', 'phill'], ['person']] -> [['Jack', 'Phill'], ['Person']]
-    for i in range(len(s)):
-        inner_list = s[i]
-        for j in range(len(inner_list)):
-            s[i][j] = s[i][j].capitalize()
-
-    # Join each inner list with hyphens and each outer list by spaces
-    # [['Jack', 'Phill'], ['Person']] -> 'Jack-Phill Person'
-    return ' '.join(['-'.join(x) for x in s])
+    # Split the name by whitespace then hyphens, capitalizing each part then
+    # joining it back together.
+    capatilized_name = " ".join(
+        "-".join(part.capitalize() for part in space_part.split("-"))
+        for space_part in name.split()
+    )
+    return capatilized_name
 
 
 def _map_email_to_displayname(address):

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -731,7 +731,8 @@ class RegisterRestServlet(RestServlet):
 
 def cap(s):
     """Capitalise words in a string, including examples such as
-    'John-Doe'"""
+    'John-Doe'
+    """
     if not s:
         return s
 

--- a/tests/handlers/test_register.py
+++ b/tests/handlers/test_register.py
@@ -239,17 +239,27 @@ class RegistrationTestCase(unittest.HomeserverTestCase):
 
     def test_email_to_displayname_mapping(self):
         """Test that custom emails are mapped to new user displaynames correctly"""
-        i = "jean-philippe.martin-laval@developpement-durable.fr"
-        expected = "Jean-Philippe Martin-Laval [Developpement-Durable]"
-        result = _map_email_to_displayname(i)
-        assert result == expected, "%s != %s" % (i, expected)
+        self._check_mapping(
+            "jean-philippe.martin-laval@developpement-durable.fr",
+            "Jean-Philippe Martin-Laval [Developpement-Durable]",
+        )
 
-        i = "bob.jones@matrix.org"
-        expected = "Bob Jones [Tchap Admin]"
-        result = _map_email_to_displayname(i)
-        assert result == expected, "%s != %s" % (i, expected)
+        self._check_mapping(
+            "bob.jones@matrix.org",
+            "Bob Jones [Tchap Admin]",
+        )
 
-        i = "bob-jones.blabla@gouv.fr"
-        expected = "Bob-Jones Blabla [Gouv]"
+        self._check_mapping(
+            "bob-jones.blabla@gouv.fr",
+            "Bob-Jones Blabla [Gouv]",
+        )
+
+        # Multibyte unicode characters
+        self._check_mapping(
+            "I♥.NY@example.com",
+            "I♥ Ny [Example]",
+        )
+
+    def _check_mapping(self, i, expected):
         result = _map_email_to_displayname(i)
-        assert result == expected, "%s != %s" % (i, expected)
+        self.assertEqual(result, expected)

--- a/tests/handlers/test_register.py
+++ b/tests/handlers/test_register.py
@@ -240,8 +240,8 @@ class RegistrationTestCase(unittest.HomeserverTestCase):
     def test_email_to_displayname_mapping(self):
         """Test that custom emails are mapped to new user displaynames correctly"""
         self._check_mapping(
-            "jean-philippe.martin-laval@developpement-durable.fr",
-            "Jean-Philippe Martin-Laval [Developpement-Durable]",
+            "jack-phillips.rivers@big-org.com",
+            "Jack-Phillips Rivers [Big-Org]",
         )
 
         self._check_mapping(
@@ -256,8 +256,8 @@ class RegistrationTestCase(unittest.HomeserverTestCase):
 
         # Multibyte unicode characters
         self._check_mapping(
-            "I♥.NY@example.com",
-            "I♥ Ny [Example]",
+            u"j\u030a\u0065an-poppy.seed@example.com",
+            u"J\u030a\u0065an-Poppy Seed [Example]",
         )
 
     def _check_mapping(self, i, expected):

--- a/tests/handlers/test_register.py
+++ b/tests/handlers/test_register.py
@@ -20,6 +20,7 @@ from twisted.internet import defer
 from synapse.api.constants import UserTypes
 from synapse.api.errors import ResourceLimitError, SynapseError
 from synapse.handlers.register import RegistrationHandler
+from synapse.rest.client.v2_alpha.register import _map_email_to_displayname
 from synapse.types import RoomAlias, UserID, create_requester
 
 from .. import unittest
@@ -235,3 +236,20 @@ class RegistrationTestCase(unittest.HomeserverTestCase):
             self.handler.register(localpart=invalid_user_id),
             SynapseError
         )
+
+    def test_email_to_displayname_mapping(self):
+        """Test that custom emails are mapped to new user displaynames correctly"""
+        i = "jean-philippe.martin-laval@developpement-durable.fr"
+        expected = "Jean-Philippe Martin-Laval [Developpement-Durable]"
+        result = _map_email_to_displayname(i)
+        assert result == expected, "%s != %s" % (i, expected)
+
+        i = "bob.jones@matrix.org"
+        expected = "Bob Jones [Tchap Admin]"
+        result = _map_email_to_displayname(i)
+        assert result == expected, "%s != %s" % (i, expected)
+
+        i = "bob-jones.blabla@gouv.fr"
+        expected = "Bob-Jones Blabla [Gouv]"
+        result = _map_email_to_displayname(i)
+        assert result == expected, "%s != %s" % (i, expected)


### PR DESCRIPTION
Makes sure email addresses like `jack-phillips.rivers@bigorg.fr` gets a displayname like:

* Jack-Phillips Rivers [BigOrg]

instead of:

* Jack-phillips Rivers [BigOrg]