### PR TITLE
Fix scripts/generate_signing_key.py import statement

### DIFF
--- a/changelog.d/15.misc
+++ b/changelog.d/15.misc
@@ -1,0 +1,1 @@
+Fix the ordering on `scripts/generate_signing_key.py`'s import statement.

--- a/scripts/generate_signing_key.py
+++ b/scripts/generate_signing_key.py
@@ -16,7 +16,7 @@
 import argparse
 import sys
 
-from signedjson.key import write_signing_keys, generate_signing_key
+from signedjson.key import generate_signing_key, write_signing_keys
 
 from synapse.util.stringutils import random_string
 


### PR DESCRIPTION
This keeps coming out as something `isort` wants to fix when I `isort` synapse's directory, so thought I'd make a PR for it to save anyone else that annoyance.