### PR TITLE
Discard retention policies when retrieving state

### DIFF
--- a/changelog.d/6436.bugfix
+++ b/changelog.d/6436.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where a room could become unusable with a low retention policy and a low activity.

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -130,7 +130,7 @@ class MessageHandler(object):
                 raise NotFoundError("Can't find event for token %s" % (at_token, ))
 
             visible_events = yield filter_events_for_client(
-                self.store, user_id, last_events,
+                self.store, user_id, last_events, apply_retention_policies=False
             )
 
             event = last_events[0]


### PR DESCRIPTION
Port of https://github.com/matrix-org/synapse/pull/6436

Purge jobs don't delete the latest event in a room in order to keep the forward extremity and not break the room. On the other hand, get_state_events, when given an at_token argument calls filter_events_for_client to know if the user can see the event that matches that (sync) token. That function uses the retention policies of the events it's given to filter out those that are too old from a client's view.

Some clients, such as Riot, when loading a room, request the list of members for the latest sync token it knows about, and get confused to the point of refusing to send any message if the server tells it that it can't get that information. This can happen very easily with the message retention feature turned on and a room with low activity so that the last event sent becomes too old according to the room's retention policy.

An easy and clean fix for that issue is to discard the room's retention policies when retrieving state.