### PR TITLE
Add some flaky sytests to a sytest-blacklist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include synctl
+include sytest-blacklist
 include LICENSE
 include VERSION
 include *.rst

--- a/changelog.d/17.misc
+++ b/changelog.d/17.misc
@@ -1,0 +1,1 @@
+Blacklist some flaky sytests until they're fixed.

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -1,0 +1,11 @@
+# flaky test
+If remote user leaves room we no longer receive device updates
+
+# flaky test
+Can re-join room if re-invited
+
+# flaky test
+Forgotten room messages cannot be paginated
+
+# flaky test
+Local device key changes get to remote servers

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -9,3 +9,6 @@ Forgotten room messages cannot be paginated
 
 # flaky test
 Local device key changes get to remote servers
+
+# flaky test
+Old leaves are present in gapped incremental syncs

--- a/tests/rest/client/v1/test_profile.py
+++ b/tests/rest/client/v1/test_profile.py
@@ -230,6 +230,7 @@ class ProfilesRestrictedTestCase(unittest.HomeserverTestCase):
 
         config = self.default_config()
         config["require_auth_for_profile_requests"] = True
+        config["limit_profile_requests_to_known_users"] = True
         self.hs = self.setup_test_homeserver(config=config)
 
         return self.hs

--- a/tests/rest/client/v1/test_profile.py
+++ b/tests/rest/client/v1/test_profile.py
@@ -230,7 +230,6 @@ class ProfilesRestrictedTestCase(unittest.HomeserverTestCase):
 
         config = self.default_config()
         config["require_auth_for_profile_requests"] = True
-        config["limit_profile_requests_to_known_users"] = True
         self.hs = self.setup_test_homeserver(config=config)
 
         return self.hs


### PR DESCRIPTION
Some sytests have started to become flaky for me: https://buildkite.com/matrix-dot-org/synapse-dinsic/builds/130#9eab680c-5cb6-4c8b-8868-11e25cc5ca9a

Add a blacklist file to prevent these from blocking a PR when necessary.

Sytest PR that uses the blacklist file: https://github.com/matrix-org/sytest/pull/757