### PR TITLE
Add limit_profile_requests_to_known_users option

### DIFF
--- a/changelog.d/18.feature
+++ b/changelog.d/18.feature
@@ -1,0 +1,1 @@
+Add option `limit_profile_requests_to_known_users` to prevent requirement of a user sharing a room with another user to query their profile information.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -77,6 +77,13 @@ pid_file: DATADIR/homeserver.pid
 #
 #require_auth_for_profile_requests: true
 
+# Whether to require a user to share a room with another user in order
+# to retrieve their profile information. Only checked on Client-Server
+# requests. Profile requests from other servers should be checked by the
+# requesting server. Defaults to 'true'.
+#
+# limit_profile_requests_to_known_users: false
+
 # If set to 'false', requires authentication to access the server's public rooms
 # directory through the client API. Defaults to 'true'.
 #

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -80,9 +80,9 @@ pid_file: DATADIR/homeserver.pid
 # Whether to require a user to share a room with another user in order
 # to retrieve their profile information. Only checked on Client-Server
 # requests. Profile requests from other servers should be checked by the
-# requesting server. Defaults to 'true'.
+# requesting server. Defaults to 'false'.
 #
-# limit_profile_requests_to_known_users: false
+# limit_profile_requests_to_known_users: true
 
 # If set to 'false', requires authentication to access the server's public rooms
 # directory through the client API. Defaults to 'true'.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -87,7 +87,7 @@ class ServerConfig(Config):
         # Whether to require sharing a room with a user to retrieve their
         # profile data
         self.limit_profile_requests_to_known_users = config.get(
-            "limit_profile_requests_to_known_users", True,
+            "limit_profile_requests_to_known_users", False,
         )
 
         if "restrict_public_rooms_to_local_users" in config and (
@@ -545,9 +545,9 @@ class ServerConfig(Config):
         # Whether to require a user to share a room with another user in order
         # to retrieve their profile information. Only checked on Client-Server
         # requests. Profile requests from other servers should be checked by the
-        # requesting server. Defaults to 'true'.
+        # requesting server. Defaults to 'false'.
         #
-        # limit_profile_requests_to_known_users: false
+        # limit_profile_requests_to_known_users: true
 
         # If set to 'false', requires authentication to access the server's public rooms
         # directory through the client API. Defaults to 'true'.

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -541,7 +541,7 @@ class ServerConfig(Config):
         # the server.
         #
         #require_auth_for_profile_requests: true
-        
+
         # Whether to require a user to share a room with another user in order
         # to retrieve their profile information. Only checked on Client-Server
         # requests. Profile requests from other servers should be checked by the

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -84,6 +84,12 @@ class ServerConfig(Config):
             "require_auth_for_profile_requests", False,
         )
 
+        # Whether to require sharing a room with a user to retrieve their
+        # profile data
+        self.limit_profile_requests_to_known_users = config.get(
+            "limit_profile_requests_to_known_users", True,
+        )
+
         if "restrict_public_rooms_to_local_users" in config and (
             "allow_public_rooms_without_auth" in config
             or "allow_public_rooms_over_federation" in config
@@ -535,6 +541,13 @@ class ServerConfig(Config):
         # the server.
         #
         #require_auth_for_profile_requests: true
+        
+        # Whether to require a user to share a room with another user in order
+        # to retrieve their profile information. Only checked on Client-Server
+        # requests. Profile requests from other servers should be checked by the
+        # requesting server. Defaults to 'true'.
+        #
+        # limit_profile_requests_to_known_users: false
 
         # If set to 'false', requires authentication to access the server's public rooms
         # directory through the client API. Defaults to 'true'.

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -441,7 +441,7 @@ class BaseProfileHandler(BaseHandler):
     @defer.inlineCallbacks
     def check_profile_query_allowed(self, target_user, requester=None):
         """Checks whether a profile query is allowed. If the
-        'require_auth_for_profile_requests' config flag is set to True and a
+        'limit_profile_requests_to_known_users' config flag is set to True and a
         'requester' is provided, the query is only allowed if the two users
         share a room.
 
@@ -459,7 +459,7 @@ class BaseProfileHandler(BaseHandler):
         # be None when this function is called outside of a profile query, e.g.
         # when building a membership event. In this case, we must allow the
         # lookup.
-        if not self.hs.config.require_auth_for_profile_requests or not requester:
+        if not self.hs.config.limit_profile_requests_to_known_users or not requester:
             return
 
         # Always allow the user to query their own profile.

--- a/tests/rest/client/v1/test_profile.py
+++ b/tests/rest/client/v1/test_profile.py
@@ -230,7 +230,7 @@ class ProfilesRestrictedTestCase(unittest.HomeserverTestCase):
 
         config = self.default_config()
         config["require_auth_for_profile_requests"] = True
-	config["limit_profile_requests_to_known_users"] = True
+        config["limit_profile_requests_to_known_users"] = True
         self.hs = self.setup_test_homeserver(config=config)
 
         return self.hs

--- a/tests/rest/client/v1/test_profile.py
+++ b/tests/rest/client/v1/test_profile.py
@@ -230,6 +230,7 @@ class ProfilesRestrictedTestCase(unittest.HomeserverTestCase):
 
         config = self.default_config()
         config["require_auth_for_profile_requests"] = True
+	config["limit_profile_requests_to_known_users"] = True
         self.hs = self.setup_test_homeserver(config=config)
 
         return self.hs


### PR DESCRIPTION
Add a config option `limit_profile_requests_to_known_users option` which controls whether a user needs to share a room with another to query their profile information.

This was actually already dictated by `require_auth_for_profile_requests`. That's now been curtailed to only handle an access token when calling the CS API. The new option now handles the "shared room" check.