### PR TITLE
Fix resetting password via a phone number

### DIFF
--- a/changelog.d/21.bugfix
+++ b/changelog.d/21.bugfix
@@ -1,0 +1,1 @@
+Fix resetting user passwords via a phone number.

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -339,7 +339,7 @@ class PasswordResetSubmitTokenServlet(RestServlet):
 
         assert_valid_client_secret(body["client_secret"])
 
-        valid, _ = yield self.datastore.validate_threepid_validation_token(
+        valid, _ = yield self.datastore.validate_threepid_session(
             body['sid'],
             body['client_secret'],
             body['token'],


### PR DESCRIPTION
We were using a non-existent method to validate 3PID sessions through the `POST` method.

This is only used for phone validation, which I don't think DINUM uses, but good to fix anyways.