### PR TITLE
Fix buggy condition in account validity handler

### DIFF
--- a/changelog.d/28.bugfix
+++ b/changelog.d/28.bugfix
@@ -1,0 +1,1 @@
+Fix a bug causing account validity renewal emails to be sent even if the feature is turned off in some cases.

--- a/synapse/handlers/account_validity.py
+++ b/synapse/handlers/account_validity.py
@@ -45,7 +45,11 @@ class AccountValidityHandler(object):
         self._show_users_in_user_directory = self.hs.config.show_users_in_user_directory
         self.profile_handler = self.hs.get_profile_handler()
 
-        if self._account_validity.renew_by_email_enabled and load_jinja2_templates:
+        if (
+            self._account_validity.enabled
+            and self._account_validity.renew_by_email_enabled
+            and load_jinja2_templates
+        ):
             # Don't do email-specific configuration if renewal by email is disabled.
             try:
                 app_name = self.hs.config.email_app_name

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -42,7 +42,9 @@ REQUIREMENTS = [
     "frozendict>=1",
     "unpaddedbase64>=1.1.0",
     "canonicaljson>=1.1.3",
-    "signedjson>=1.0.0",
+    # Pin signedjson to 1.0.0 because this version of Synapse relies on a function that's
+    # been removed in 1.1.0. Hopefully, this will be fixed by the upcoming mainline merge.
+    "signedjson==1.0.0",
     "pynacl>=1.2.1",
     "idna>=2",
 


### PR DESCRIPTION
Otherwise renewal emails would be sent even if `enabled` is set to `false` in the account validity config.