### PR TITLE
Add the UserDirectoryStore to the ClientReaderSlavedStore.

### DIFF
--- a/changelog.d/32.bugfix
+++ b/changelog.d/32.bugfix
@@ -1,0 +1,1 @@
+Fixes a bug when using the default display name during registration.

--- a/synapse/app/client_reader.py
+++ b/synapse/app/client_reader.py
@@ -44,6 +44,7 @@ from synapse.replication.slave.storage.receipts import SlavedReceiptsStore
 from synapse.replication.slave.storage.registration import SlavedRegistrationStore
 from synapse.replication.slave.storage.room import RoomStore
 from synapse.replication.slave.storage.transactions import SlavedTransactionStore
+from synapse.replication.slave.storage.user_directory import SlavedUserDirectoryStore
 from synapse.replication.tcp.client import ReplicationClientHandler
 from synapse.rest.client.v1.login import LoginRestServlet
 from synapse.rest.client.v1.push_rule import PushRuleRestServlet
@@ -84,6 +85,7 @@ class ClientReaderSlavedStore(
     SlavedTransactionStore,
     SlavedProfileStore,
     SlavedClientIpStore,
+    SlavedUserDirectoryStore,
     BaseSlavedStore,
 ):
     pass

--- a/synapse/replication/slave/storage/user_directory.py
+++ b/synapse/replication/slave/storage/user_directory.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from synapse.storage.user_directory import UserDirectoryStore
+
+from ._base import BaseSlavedStore
+
+
+class SlavedUserDirectoryStore(UserDirectoryStore, BaseSlavedStore):
+    pass


### PR DESCRIPTION
This is necessary for the register API endpoint to be able to access the user directory.

This PR takes a naive approach to pass the store through. I'm fairly confident the method in question (`update_profile_in_user_dir`) is OK to run on a worker, but not sure if the other methods are.

This differs a bit from master, due to 32e4420a6678f1cfa4a3e488cff2d219ca326950.