### PR TITLE
Prevent M_USER_IN_USE from being raised by registration methods until after email has been verified

### DIFF
--- a/changelog.d/48.feature
+++ b/changelog.d/48.feature
@@ -1,0 +1,1 @@
+Prevent `/register` from raising `M_USER_IN_USE` until UI Auth has been completed. Prevent `/register/available` from raising `M_USER_IN_USE` at all.

--- a/changelog.d/48.feature
+++ b/changelog.d/48.feature
@@ -1,1 +1,1 @@
-Prevent `/register` from raising `M_USER_IN_USE` until UI Auth has been completed. Prevent `/register/available` from raising `M_USER_IN_USE` at all.
+Prevent `/register` from raising `M_USER_IN_USE` until UI Auth has been completed. Have `/register/available` always return true.

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -131,8 +131,6 @@ class RegistrationHandler(BaseHandler):
         users = yield self.store.get_users_by_id_case_insensitive(user_id)
         if users:
             if not guest_access_token:
-                # Note that we don't want to give this exception to any clients, as they
-                # could use it to infer whether a user exists on a server or not
                 raise SynapseError(
                     400, "User ID already taken.", errcode=Codes.USER_IN_USE
                 )

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -136,12 +136,16 @@ class RegistrationHandler(BaseHandler):
 
         users = yield self.store.get_users_by_id_case_insensitive(user_id)
         if users:
-            if not guest_access_token and user_in_use_exception:
-                # Note that we don't want to give this exception to any clients, as they
-                # could use it to infer whether a user exists on a server or not
-                raise SynapseError(
-                    400, "User ID already taken.", errcode=Codes.USER_IN_USE
-                )
+            if not guest_access_token:
+                if user_in_use_exception:
+                    # Note that we don't want to give this exception to any clients, as they
+                    # could use it to infer whether a user exists on a server or not
+                    raise SynapseError(
+                        400, "User ID already taken.", errcode=Codes.USER_IN_USE
+                    )
+                return
+
+            # Retrieve guest user information from provided access token
             user_data = yield self.auth.get_user_by_access_token(guest_access_token)
             if not user_data["is_guest"] or user_data["user"].localpart != localpart:
                 raise AuthError(

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -80,11 +80,7 @@ class RegistrationHandler(BaseHandler):
 
     @defer.inlineCallbacks
     def check_username(
-        self,
-        localpart,
-        guest_access_token=None,
-        assigned_user_id=None,
-        user_in_use_exception=True,
+        self, localpart, guest_access_token=None, assigned_user_id=None,
     ):
         """
 
@@ -92,8 +88,6 @@ class RegistrationHandler(BaseHandler):
             localpart (str|None): The user's localpart
             guest_access_token (str|None): A guest's access token
             assigned_user_id (str|None): An existing User ID for this user if pre-calculated
-            user_in_use_exception (bool): Whether to raise an M_USER_IN_USE error if the
-                user ID already exists in the database
 
         Returns:
             Deferred
@@ -137,13 +131,11 @@ class RegistrationHandler(BaseHandler):
         users = yield self.store.get_users_by_id_case_insensitive(user_id)
         if users:
             if not guest_access_token:
-                if user_in_use_exception:
-                    # Note that we don't want to give this exception to any clients, as they
-                    # could use it to infer whether a user exists on a server or not
-                    raise SynapseError(
-                        400, "User ID already taken.", errcode=Codes.USER_IN_USE
-                    )
-                return
+                # Note that we don't want to give this exception to any clients, as they
+                # could use it to infer whether a user exists on a server or not
+                raise SynapseError(
+                    400, "User ID already taken.", errcode=Codes.USER_IN_USE
+                )
 
             # Retrieve guest user information from provided access token
             user_data = yield self.auth.get_user_by_access_token(guest_access_token)

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -437,8 +437,8 @@ class RegisterRestServlet(RestServlet):
             body["password_hash"] = await self.auth_handler.hash(password)
             desired_password_hash = body["password_hash"]
 
-        # We don't care about usernames for this deployments. In fact,
-        # the act of checking whether they exist already can leak metadata about
+        # We don't care about usernames for this deployment. In fact, the act
+        # of checking whether they exist already can leak metadata about
         # which users are already registered.
         #
         # Usernames are already derived via the provided email.

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -528,6 +528,7 @@ class RegisterRestServlet(RestServlet):
                 desired_username,
                 guest_access_token=guest_access_token,
                 assigned_user_id=registered_user_id,
+                user_in_use_exception=False,
             )
 
         auth_result, params, session_id = await self.auth_handler.check_auth(

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -357,19 +357,9 @@ class UsernameAvailabilityRestServlet(RestServlet):
                 403, "Registration has been disabled", errcode=Codes.FORBIDDEN
             )
 
-        ip = self.hs.get_ip_from_request(request)
-        with self.ratelimiter.ratelimit(ip) as wait_deferred:
-            await wait_deferred
-
-            username = parse_string(request, "username", required=True)
-
-            await self.registration_handler.check_username(
-                username,
-                # Prevent leaking information to the client about whether a username is in use
-                user_in_use_exception=False,
-            )
-
-            return 200, {"available": True}
+        # We are not interested in logging in via a username in this deployment.
+        # Simply allow anything here as it won't be used later.
+        return 200, {"available": True}
 
 
 class RegisterRestServlet(RestServlet):

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -363,7 +363,11 @@ class UsernameAvailabilityRestServlet(RestServlet):
 
             username = parse_string(request, "username", required=True)
 
-            await self.registration_handler.check_username(username)
+            await self.registration_handler.check_username(
+                username,
+                # Prevent leaking information to the client about whether a username is in use
+                user_in_use_exception=False,
+            )
 
             return 200, {"available": True}
 

--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -437,14 +437,15 @@ class RegisterRestServlet(RestServlet):
             body["password_hash"] = await self.auth_handler.hash(password)
             desired_password_hash = body["password_hash"]
 
+        # We don't care about usernames for this deployments. In fact,
+        # the act of checking whether they exist already can leak metadata about
+        # which users are already registered.
+        #
+        # Usernames are already derived via the provided email.
+        # So, if they're not necessary, just ignore them.
+        #
+        # (we do still allow appservices to set them below)
         desired_username = None
-        if "username" in body:
-            if (
-                not isinstance(body["username"], string_types)
-                or len(body["username"]) > 512
-            ):
-                raise SynapseError(400, "Invalid username")
-            desired_username = body["username"]
 
         desired_display_name = body.get("display_name")
 
@@ -460,7 +461,7 @@ class RegisterRestServlet(RestServlet):
             # Set the desired user according to the AS API (which uses the
             # 'user' key not 'username'). Since this is a new addition, we'll
             # fallback to 'username' if they gave one.
-            desired_username = body.get("user", desired_username)
+            desired_username = body.get("user", body.get("username"))
 
             # XXX we should check that desired_username is valid. Currently
             # we give appservices carte blanche for any insanity in mxids,
@@ -478,15 +479,6 @@ class RegisterRestServlet(RestServlet):
                     body,
                 )
             return 200, result  # we throw for non 200 responses
-
-        # for regular registration, downcase the provided username before
-        # attempting to register it. This should mean
-        # that people who try to register with upper-case in their usernames
-        # don't get a nasty surprise. (Note that we treat username
-        # case-insenstively in login, so they are free to carry on imagining
-        # that their username is CrAzYh4cKeR if that keeps them happy)
-        if desired_username is not None:
-            desired_username = desired_username.lower()
 
         # == Normal User Registration == (everyone else)
         if not self.hs.config.enable_registration:
@@ -511,14 +503,6 @@ class RegisterRestServlet(RestServlet):
             # for paranoia.
             registered_user_id = await self.auth_handler.get_session_data(
                 session_id, "registered_user_id", None
-            )
-
-        if desired_username is not None:
-            await self.registration_handler.check_username(
-                desired_username,
-                guest_access_token=guest_access_token,
-                assigned_user_id=registered_user_id,
-                user_in_use_exception=False,
             )
 
         auth_result, params, session_id = await self.auth_handler.check_auth(

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -90,14 +90,6 @@ class RegisterRestServletTestCase(unittest.HomeserverTestCase):
         self.assertEquals(channel.result["code"], b"400", channel.result)
         self.assertEquals(channel.json_body["error"], "Invalid password")
 
-    def test_POST_bad_username(self):
-        request_data = json.dumps({"username": 777, "password": "monkey"})
-        request, channel = self.make_request(b"POST", self.url, request_data)
-        self.render(request)
-
-        self.assertEquals(channel.result["code"], b"400", channel.result)
-        self.assertEquals(channel.json_body["error"], "Invalid username")
-
     def test_POST_user_valid(self):
         user_id = "@kermit:test"
         device_id = "frogfone"


### PR DESCRIPTION
Prevents `M_USER_IN_USE` from being returned to the client before they're verified an associated email.