### PR TITLE
Add option to autobind user's email on registration

### DIFF
--- a/changelog.d/51.feature
+++ b/changelog.d/51.feature
@@ -1,0 +1,1 @@
+Add `bind_new_user_emails_to_sydent` option for automatically binding user's emails after registration.

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1387,6 +1387,24 @@ account_threepid_delegates:
 #rewrite_identity_server_urls:
 #   "https://somewhere.example.com": "https://somewhereelse.example.com"
 
+# When a user registers an account with an email address, it can be useful to
+# bind that email address to their mxid on an identity server. Typically, this
+# requires the user to validate their email address with the identity server.
+# However if Synapse itself is handling email validation on registration, the
+# user ends up needing to validate their email twice, which leads to poor UX.
+#
+# It is possible to force Sydent, one identity server implementation, to bind
+# threepids using its internal, unauthenticated bind API:
+# https://github.com/matrix-org/sydent/#internal-bind-and-unbind-api
+#
+# Configure the address of a Sydent server here to have Synapse attempt
+# to automatically bind users' emails following registration. The
+# internal bind API must be reachable from Synapse, but should NOT be
+# exposed to any third party, as it allows the creation of bindings
+# without validation.
+#
+#bind_new_user_emails_to_sydent: https://example.com:8091
+
 
 ## Metrics ###
 

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -1033,6 +1033,29 @@ class IdentityHandler(BaseHandler):
         display_name = data["display_name"]
         return token, public_keys, fallback_public_key, display_name
 
+    async def bind_email_using_internal_sydent_api(
+        self, id_server_url: str, email: str, user_id: str,
+    ):
+        """Bind an email to a fully qualified user ID on an instance of Sydent.
+
+        Args:
+            id_server_url: The URL of the Sydent instance
+            email: The email address to bind
+            user_id: The user ID to bind the email to
+
+        Raises:
+            HTTPResponseException: On a non-2xx HTTP response.
+        """
+        # id_server_url is assumed to have no trailing slashes
+        url = id_server_url + "/_matrix/identity/internal/bind"
+        body = {
+            "address": email,
+            "medium": "email",
+            "mxid": user_id,
+        }
+
+        await self.http_client.post_json_get_json(url, body)
+
 
 def create_id_access_token_header(id_access_token):
     """Create an Authorization header for passing to SimpleHttpClient as the header value

--- a/synapse/handlers/identity.py
+++ b/synapse/handlers/identity.py
@@ -1036,7 +1036,8 @@ class IdentityHandler(BaseHandler):
     async def bind_email_using_internal_sydent_api(
         self, id_server_url: str, email: str, user_id: str,
     ):
-        """Bind an email to a fully qualified user ID on an instance of Sydent.
+        """Bind an email to a fully qualified user ID using the internal API of an
+        instance of Sydent.
 
         Args:
             id_server_url: The URL of the Sydent instance

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -636,6 +636,21 @@ class RegistrationHandler(BaseHandler):
 
         if auth_result and LoginType.EMAIL_IDENTITY in auth_result:
             threepid = auth_result[LoginType.EMAIL_IDENTITY]
+
+            if "medium" not in threepid or "address" not in threepid:
+                raise SynapseError(
+                    400,
+                    "Invalid %s authdict" % (LoginType.EMAIL_IDENTITY,),
+                    errcode=Codes.INVALID_PARAM,
+                )
+
+            if threepid["medium"] != "email":
+                raise SynapseError(
+                    400,
+                    "Invalid medium %s" % (threepid["medium"],),
+                    errcode=Codes.INVALID_PARAM,
+                )
+
             # Necessary due to auth checks prior to the threepid being
             # written to the db
             if is_threepid_reserved(
@@ -645,34 +660,30 @@ class RegistrationHandler(BaseHandler):
 
             await self.register_email_threepid(user_id, threepid, access_token)
 
-            if self.hs.config.account_threepid_delegate_email:
-                # Bind the 3PID to the identity server
+            if self.hs.config.bind_new_user_emails_to_sydent:
+                # Attempt to call Sydent's internal bind API on the given identity server
+                # to bind this threepid
+                id_server_url = self.hs.config.bind_new_user_emails_to_sydent
+
                 logger.debug(
-                    "Binding email to %s on id_server %s",
+                    "Attempting the bind email of %s to identity server: %s using "
+                    "internal Sydent bind API.",
                     user_id,
-                    self.hs.config.account_threepid_delegate_email,
+                    self.hs.config.bind_new_user_emails_to_sydent,
                 )
-                threepid_creds = threepid["threepid_creds"]
 
-                # Remove the protocol scheme before handling to `bind_threepid`
-                # `bind_threepid` will add https:// to it, so this restricts
-                # account_threepid_delegate.email to https:// addresses only
-                # We assume this is always the case for dinsic however.
-                if self.hs.config.account_threepid_delegate_email.startswith(
-                    "https://"
-                ):
-                    id_server = self.hs.config.account_threepid_delegate_email[8:]
-                else:
-                    # Must start with http:// instead
-                    id_server = self.hs.config.account_threepid_delegate_email[7:]
-
-                await self.identity_handler.bind_threepid(
-                    threepid_creds["client_secret"],
-                    threepid_creds["sid"],
-                    user_id,
-                    id_server,
-                    threepid_creds.get("id_access_token"),
-                )
+                try:
+                    await self.identity_handler.bind_email_using_internal_sydent_api(
+                        id_server_url, threepid["address"], user_id
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Failed to bind email of '%s' to Sydent instance '%s' ",
+                        "using Sydent internal bind API: %s",
+                        user_id,
+                        id_server_url,
+                        e,
+                    )
 
         if auth_result and LoginType.MSISDN in auth_result:
             threepid = auth_result[LoginType.MSISDN]

--- a/synapse/handlers/register.py
+++ b/synapse/handlers/register.py
@@ -637,20 +637,6 @@ class RegistrationHandler(BaseHandler):
         if auth_result and LoginType.EMAIL_IDENTITY in auth_result:
             threepid = auth_result[LoginType.EMAIL_IDENTITY]
 
-            if "medium" not in threepid or "address" not in threepid:
-                raise SynapseError(
-                    400,
-                    "Invalid %s authdict" % (LoginType.EMAIL_IDENTITY,),
-                    errcode=Codes.INVALID_PARAM,
-                )
-
-            if threepid["medium"] != "email":
-                raise SynapseError(
-                    400,
-                    "Invalid medium %s" % (threepid["medium"],),
-                    errcode=Codes.INVALID_PARAM,
-                )
-
             # Necessary due to auth checks prior to the threepid being
             # written to the db
             if is_threepid_reserved(


### PR DESCRIPTION
Adds an option, `bind_new_user_emails_to_sydent`, which uses Sydent's [internal bind api](https://github.com/matrix-org/sydent#internal-bind-and-unbind-api) to automatically bind email addresses of users immediately after they register.

This is quite enterprise-specific, but could be generally useful to multiple organizations. This aims to solve the problem of requiring users to verify their email twice when using the functionality of an identity server in a corporate deployment - where both the homeserver and identity server are controlled. It does with while eliminating the need for the `account_threepid_delegates.email` option, which historically has been a very complicated option to reason about.

~~This is implemented as an option in preparation for potentially mainlining the code.~~ We've decided it should be mainlined in module form instead.

TODO:
  - [x] unit tests