### PR TITLE
Revert "Remove "user_id" from GET /presence. (#7606)"

### DIFF
--- a/changelog.d/56.misc
+++ b/changelog.d/56.misc
@@ -1,0 +1,1 @@
+Temporarily revert #7606.

--- a/changelog.d/56.misc
+++ b/changelog.d/56.misc
@@ -1,1 +1,1 @@
-Temporarily revert #7606.
+Temporarily revert commit a3fbc23.

--- a/synapse/rest/client/v1/presence.py
+++ b/synapse/rest/client/v1/presence.py
@@ -49,9 +49,7 @@ class PresenceStatusRestServlet(RestServlet):
                 raise AuthError(403, "You are not allowed to see their presence.")
 
         state = await self.presence_handler.get_state(target_user=user)
-        state = format_user_presence_state(
-            state, self.clock.time_msec(), include_user_id=False
-        )
+        state = format_user_presence_state(state, self.clock.time_msec())
 
         return 200, state
 


### PR DESCRIPTION
This reverts commit a3fbc23c39c0366392fd51faf0b1696f1f1d21c7.

Doing this as a temporary fix to the Tchap clients crashing because of the lack of `user_id` in the presence responses.

We'll need to revert this reversion when a new version of the Tchap clients is released.