### PR TITLE
"Freeze" a room when the last admin of that room leaves

### DIFF
--- a/changelog.d/59.feature
+++ b/changelog.d/59.feature
@@ -1,0 +1,1 @@
+Freeze a room when the last administrator in the room leaves.

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -498,16 +498,13 @@ class RoomAccessRules(object):
             # This user is not an admin, ignore them
             return
 
-        # Filter these users to only those who are actually joined or invited to the room
-        joined_members = [
-            user_id
-            for (event_type, user_id), event in state_events.items()
-            if event_type == EventTypes.Member
+        if any(
+            event_type == EventTypes.Member
             and event.membership in [Membership.JOIN, Membership.INVITE]
-        ]
-        admin_users = {user for user in admin_users if user in joined_members}
-
-        if len(admin_users) > 1:
+            and state_key in admin_users
+            and state_key != user_id
+            for (event_type, state_key), event in state_events.items()
+        ):
             # There's another admin user in, or invited to, the room
             return
 

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -508,6 +508,7 @@ class RoomAccessRules(object):
             # There's another admin user in, or invited to, the room
             return
 
+        # Freeze the room by raising the required power level to send events to 100
         logger.info("Freezing room '%s'", event.room_id)
 
         # Modify the existing power levels to raise all required types to 100
@@ -565,7 +566,6 @@ class RoomAccessRules(object):
                 power_level_content[key] = 100
         power_level_content["events"] = {}
 
-        # Freeze the room by raising the required power level to send events to 100
         await self.module_api.create_and_send_event_into_room(
             {
                 "room_id": event.room_id,

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -511,6 +511,8 @@ class RoomAccessRules(object):
             # There's another admin user in, or invited to, the room
             return
 
+        logger.info("Freezing room '%s'", event.room_id)
+
         # Modify the existing power levels to raise all required types to 100
         #
         # This changes a power level state event's content from something like:
@@ -567,8 +569,6 @@ class RoomAccessRules(object):
         power_level_content["events"] = {}
 
         # Freeze the room by raising the required power level to send events to 100
-        logger.info("Freezing room '%s'", event.room_id)
-
         await self.module_api.create_and_send_event_into_room(
             {
                 "room_id": event.room_id,

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -488,11 +488,11 @@ class RoomAccessRules(object):
             return
 
         # Get every admin user defined in the room's state
-        admin_users = [
+        admin_users = {
             user
             for user, power_level in power_level_content["users"].items()
             if power_level >= 100
-        ]
+        }
 
         if user_id not in admin_users:
             # This user is not an admin, ignore them
@@ -505,7 +505,7 @@ class RoomAccessRules(object):
             if event_type == EventTypes.Member
             and event.membership in [Membership.JOIN, Membership.INVITE]
         ]
-        admin_users = [user for user in admin_users if user in joined_members]
+        admin_users = {user for user in admin_users if user in joined_members}
 
         if len(admin_users) > 1:
             # There's another admin user in, or invited to, the room

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -473,7 +473,7 @@ class RoomAccessRules(object):
         )  # type: EventBase
         if not power_level_state_event:
             return
-        power_level_content = power_level_state_event.content
+        power_level_content = power_level_state_event.content.copy()
         if not isinstance(power_level_content, dict):
             # The power level content has been set to something other than a dict...
             # bail out.

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -466,8 +466,6 @@ class RoomAccessRules(object):
     async def _freeze_room_if_last_admin_is_leaving(
         self, event: EventBase, state_events: StateMap[EventBase]
     ):
-        logger.info("Freezing room '%s'", event.room_id)
-
         power_level_state_event = state_events.get(
             (EventTypes.PowerLevels, "")
         )  # type: EventBase
@@ -563,6 +561,8 @@ class RoomAccessRules(object):
         power_level_content["events"] = {}
 
         # Freeze the room by raising the required power level to send events to 100
+        logger.info("Freezing room '%s'", event.room_id)
+
         await self.module_api.create_and_send_event_into_room(
             {
                 "room_id": event.room_id,

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -567,14 +567,25 @@ class RoomAccessRules(object):
                 value = 100
             new_content[key] = value
 
-        # Clear out any special-case event power levels
-        new_content["events"] = {}
-
-        # Ensure state_default and events_default keys exist and are 100
-        # Else a lower PL user could potentially send state events that
-        # aren't explicitly mentioned elsewhere in the power level dict
-        new_content["state_default"] = 100
-        new_content["events_default"] = 100
+        # Set some values in case they are missing from the original
+        # power levels event content
+        new_content.update(
+            {
+                # Clear out any special-cased event keys
+                "events": {},
+                # Ensure state_default and events_default keys exist and are 100.
+                # Otherwise a lower PL user could potentially send state events that
+                # aren't explicitly mentioned elsewhere in the power level dict
+                "state_default": 100,
+                "events_default": 100,
+                # Membership events default to 50 if they aren't present. Set them
+                # to 100 here, as they would be set to 100 if they were present anyways
+                "ban": 100,
+                "kick": 100,
+                "invite": 100,
+                "redact": 100,
+            }
+        )
 
         await self.module_api.create_and_send_event_into_room(
             {

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -472,9 +472,15 @@ class RoomAccessRules(object):
         if not power_level_state_event:
             return
         power_level_content = power_level_state_event.content.copy()
-        if not isinstance(power_level_content, dict):
-            # The power level content has been set to something other than a dict...
-            # bail out.
+
+        # Do some validation checks on the power level state event
+        if (
+            not isinstance(power_level_content, dict)
+            or "users" not in power_level_content
+            or not isinstance(power_level_content["users"], dict)
+        ):
+            # We can't use this power level event to determine whether the room should be
+            # frozen. Bail out.
             return
 
         user_id = event.get("sender")

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -927,7 +927,7 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         freeze_room_with_id_and_power_levels(room1)
 
         # Test that freezing a room with a power level state event that is missing
-        # `state_default` and `event_default` keys works
+        # `state_default` and `event_default` keys behaves as expected
         room2 = self.create_room()
         freeze_room_with_id_and_power_levels(
             room2,
@@ -946,6 +946,26 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
                 "users": {self.user_id: 100},
                 "users_default": 0,
                 # Explicitly remove `state_default` and `event_default` keys
+            },
+        )
+
+        # Test that freezing a room with a power level state event that is *additionally*
+        # missing `ban`, `invite`, `kick` and `redact` keys behaves as expected
+        room3 = self.create_room()
+        freeze_room_with_id_and_power_levels(
+            room3,
+            {
+                "events": {
+                    "m.room.avatar": 50,
+                    "m.room.canonical_alias": 50,
+                    "m.room.history_visibility": 100,
+                    "m.room.name": 50,
+                    "m.room.power_levels": 100,
+                },
+                "users": {self.user_id: 100},
+                "users_default": 0,
+                # Explicitly remove `state_default` and `event_default` keys
+                # Explicitly remove `ban`, `invite`, `kick and `redact` keys
             },
         )
 

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -965,7 +965,7 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
                 "users": {self.user_id: 100},
                 "users_default": 0,
                 # Explicitly remove `state_default` and `event_default` keys
-                # Explicitly remove `ban`, `invite`, `kick and `redact` keys
+                # Explicitly remove `ban`, `invite`, `kick` and `redact` keys
             },
         )
 

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -15,6 +15,7 @@
 import json
 import random
 import string
+from typing import Optional
 
 from mock import Mock
 
@@ -28,7 +29,7 @@ from synapse.third_party_rules.access_rules import (
     AccessRules,
     RoomAccessRules,
 )
-from synapse.types import create_requester
+from synapse.types import JsonDict, create_requester
 
 from tests import unittest
 
@@ -844,79 +845,109 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         """Tests that the power levels in a room change to prevent new events from
         non-admin users when the last admin of a room leaves.
         """
-        # Invite a user to the room, they join with PL 0
-        self.helper.invite(
-            room=self.restricted_room,
-            src=self.user_id,
-            targ=self.invitee_id,
-            tok=self.tok,
+
+        def freeze_room_with_id_and_power_levels(
+            room_id: str, custom_power_levels_content: Optional[JsonDict] = None,
+        ):
+            # Invite a user to the room, they join with PL 0
+            self.helper.invite(
+                room=room_id, src=self.user_id, targ=self.invitee_id, tok=self.tok,
+            )
+
+            # Invitee joins the room
+            self.helper.join(
+                room=room_id, user=self.invitee_id, tok=self.invitee_tok,
+            )
+
+            if not custom_power_levels_content:
+                # Retrieve the room's current power levels event content
+                power_levels = self.helper.get_state(
+                    room_id=room_id, event_type="m.room.power_levels", tok=self.tok,
+                )
+            else:
+                power_levels = custom_power_levels_content
+
+                # Override the room's power levels with the given power levels content
+                self.helper.send_state(
+                    room_id=room_id,
+                    event_type="m.room.power_levels",
+                    body=custom_power_levels_content,
+                    tok=self.tok,
+                )
+
+            # Ensure that the invitee leaving the room does not change the power levels
+            self.helper.leave(
+                room=room_id, user=self.invitee_id, tok=self.invitee_tok,
+            )
+
+            # Retrieve the new power levels of the room
+            new_power_levels = self.helper.get_state(
+                room_id=room_id, event_type="m.room.power_levels", tok=self.tok,
+            )
+
+            # Ensure they have not changed
+            self.assertDictEqual(power_levels, new_power_levels)
+
+            # Invite the user back again
+            self.helper.invite(
+                room=room_id, src=self.user_id, targ=self.invitee_id, tok=self.tok,
+            )
+
+            # Invitee joins the room
+            self.helper.join(
+                room=room_id, user=self.invitee_id, tok=self.invitee_tok,
+            )
+
+            # Now the admin leaves the room
+            self.helper.leave(
+                room=room_id, user=self.user_id, tok=self.tok,
+            )
+
+            # Check the power levels again
+            new_power_levels = self.helper.get_state(
+                room_id=room_id, event_type="m.room.power_levels", tok=self.invitee_tok,
+            )
+
+            # Ensure that the new power levels prevent anyone but admins from sending
+            # certain events
+            self.assertEquals(new_power_levels["state_default"], 100)
+            self.assertEquals(new_power_levels["events_default"], 100)
+            self.assertEquals(new_power_levels["kick"], 100)
+            self.assertEquals(new_power_levels["invite"], 100)
+            self.assertEquals(new_power_levels["ban"], 100)
+            self.assertEquals(new_power_levels["redact"], 100)
+            self.assertDictEqual(new_power_levels["events"], {})
+            self.assertDictEqual(new_power_levels["users"], {self.user_id: 100})
+
+            # Ensure new users entering the room aren't going to immediately become admins
+            self.assertEquals(new_power_levels["users_default"], 0)
+
+        # Test that freezing a room with the default power level state event content works
+        room1 = self.create_room()
+        freeze_room_with_id_and_power_levels(room1)
+
+        # Test that freezing a room with a power level state event that is missing
+        # `state_default` and `event_default` keys works
+        room2 = self.create_room()
+        freeze_room_with_id_and_power_levels(
+            room2,
+            {
+                "ban": 50,
+                "events": {
+                    "m.room.avatar": 50,
+                    "m.room.canonical_alias": 50,
+                    "m.room.history_visibility": 100,
+                    "m.room.name": 50,
+                    "m.room.power_levels": 100,
+                },
+                "invite": 0,
+                "kick": 50,
+                "redact": 50,
+                "users": {self.user_id: 100},
+                "users_default": 0,
+                # Explicitly remove `state_default` and `event_default` keys
+            },
         )
-
-        # Invitee joins the room
-        self.helper.join(
-            room=self.restricted_room, user=self.invitee_id, tok=self.invitee_tok,
-        )
-
-        # Retrieve the room's current power levels event content
-        power_levels = self.helper.get_state(
-            room_id=self.restricted_room,
-            event_type="m.room.power_levels",
-            tok=self.tok,
-        )
-
-        # Ensure that the invitee leaving the room does not change the power levels
-        self.helper.leave(
-            room=self.restricted_room, user=self.invitee_id, tok=self.invitee_tok,
-        )
-
-        # Retrieve the new power levels of the room
-        new_power_levels = self.helper.get_state(
-            room_id=self.restricted_room,
-            event_type="m.room.power_levels",
-            tok=self.tok,
-        )
-
-        # Ensure they have not changed
-        self.assertDictEqual(power_levels, new_power_levels)
-
-        # Invite the user back again
-        self.helper.invite(
-            room=self.restricted_room,
-            src=self.user_id,
-            targ=self.invitee_id,
-            tok=self.tok,
-        )
-
-        # Invitee joins the room
-        self.helper.join(
-            room=self.restricted_room, user=self.invitee_id, tok=self.invitee_tok,
-        )
-
-        # Now the admin leaves the room
-        self.helper.leave(
-            room=self.restricted_room, user=self.user_id, tok=self.tok,
-        )
-
-        # Check the power levels again
-        new_power_levels = self.helper.get_state(
-            room_id=self.restricted_room,
-            event_type="m.room.power_levels",
-            tok=self.invitee_tok,
-        )
-
-        # Ensure that the new power levels prevent anyone but admins from sending
-        # certain events
-        self.assertEquals(new_power_levels["state_default"], 100)
-        self.assertEquals(new_power_levels["events_default"], 100)
-        self.assertEquals(new_power_levels["kick"], 100)
-        self.assertEquals(new_power_levels["invite"], 100)
-        self.assertEquals(new_power_levels["ban"], 100)
-        self.assertEquals(new_power_levels["redact"], 100)
-        self.assertDictEqual(new_power_levels["events"], {})
-        self.assertDictEqual(new_power_levels["users"], {self.user_id: 100})
-
-        # Ensure new users entering the room aren't going to immediately become admins
-        self.assertEquals(new_power_levels["users_default"], 0)
 
     def create_room(
         self,


### PR DESCRIPTION
If the last admin of a room departs, and thus the room no longer has any admins within it, we "freeze" the room. Freezing a room means that the power level required to do anything in the room (sending messages, inviting others etc) will require power level 100.

At the moment, an admin can come back and unfreeze the room manually. The plan is to eventually make unfreezing of the room automatic on admin rejoin, though that will be in a separate PR.

This *could* work in mainline, however if the admin who leaves is on a homeserver without this functionality, then the room isn't frozen. I imagine this would probably be pretty confusing to people. Part of this feature was allowing Synapse modules to send events, which has been implemented in mainline at  https://github.com/matrix-org/synapse/pull/8479, and cherry-picked to the `dinsic` fork in 62c7b10. The actual freezing logic has been implemented here in the RoomAccessRules module.

Reviewable commit-by-commit, commit messages have the breakdown.