### PR TITLE
Override the power levels defaults, enforce mod requirement for invites, admin requirements for unknown state events

### DIFF
--- a/changelog.d/61.misc
+++ b/changelog.d/61.misc
@@ -1,0 +1,1 @@
+Change the minimum power levels for invites and other state events in new rooms.

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -533,6 +533,10 @@ class RoomAccessRules(object):
             Whether the content of the power levels event is valid.
         """
         # Only enforce these rules during room creation
+        #
+        # We want to allow admins to modify or fix the power levels in a room if they
+        # have a special circumstance, but still want to encourage a certain pattern during
+        # room creation.
         if on_room_creation:
             # If invite requirements are <PL50
             if content.get("invite", 50) < 50:

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -111,8 +111,8 @@ class RoomAccessRules(object):
         default rule to the initial state.
 
         Checks if a m.rooms.power_levels event is being set during room creation.
-        If yes, make sure the event is allowed. Otherwise, append an event with custom
-        default rules to the initial state.
+        If yes, make sure the event is allowed. Otherwise, set power_level_content_override
+        in the config dict to our modified version of the default room power levels.
 
         Args:
             requester: The user who is making the createRoom request.

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -110,6 +110,10 @@ class RoomAccessRules(object):
         If yes, make sure the event is correct. Otherwise, append an event with the
         default rule to the initial state.
 
+        Checks if a m.rooms.power_levels event is being set during room creation.
+        If yes, make sure the event is allowed. Otherwise, append an event with custom
+        default rules to the initial state.
+
         Args:
             requester: The user who is making the createRoom request.
             config: The createRoom config dict provided by the user.

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 import json
 import random
 import string
@@ -30,6 +28,7 @@ from synapse.third_party_rules.access_rules import (
     ACCESS_RULE_RESTRICTED,
     ACCESS_RULE_UNRESTRICTED,
     ACCESS_RULES_TYPE,
+    RoomAccessRules,
 )
 
 from tests import unittest
@@ -155,6 +154,52 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         """Tests that creating a direct room with an invalid rule will fail.
         """
         self.create_room(direct=True, rule=ACCESS_RULE_RESTRICTED, expected_code=400)
+
+    def test_create_room_default_power_level_rules(self):
+        """Tests that a room created with no power level overrides instead uses the dinum
+        defaults
+        """
+        room_id = self.create_room(direct=True, rule=ACCESS_RULE_DIRECT)
+        power_levels = self.helper.get_state(room_id, "m.room.power_levels", self.tok)
+
+        # Inviting another user should require PL50, even in private rooms
+        self.assertEqual(power_levels["invite"], 50)
+        # Sending arbitrary state events should require PL100
+        self.assertEqual(power_levels["state_default"], 100)
+
+    def test_create_room_fails_on_incorrect_power_level_rules(self):
+        """Tests that a room created with power levels lower than that required are rejected"""
+        modified_power_levels = RoomAccessRules._get_default_power_levels(self.user_id)
+        modified_power_levels["invite"] = 0
+        modified_power_levels["state_default"] = 50
+
+        self.create_room(
+            direct=True,
+            rule=ACCESS_RULE_DIRECT,
+            initial_state=[
+                {"type": "m.room.power_levels", "content": modified_power_levels}
+            ],
+            expected_code=400,
+        )
+
+    def test_existing_room_can_change_power_levels(self):
+        """Tests that a room created with default power levels can have their power levels
+        dropped after room creation
+        """
+        # Creates a room with the default power levels
+        room_id = self.create_room(
+            direct=True, rule=ACCESS_RULE_DIRECT, expected_code=200,
+        )
+
+        # Attempt to drop invite and state_default power levels after the fact
+        room_power_levels = self.helper.get_state(
+            room_id, "m.room.power_levels", self.tok
+        )
+        room_power_levels["invite"] = 0
+        room_power_levels["state_default"] = 50
+        self.helper.send_state(
+            room_id, "m.room.power_levels", room_power_levels, self.tok
+        )
 
     def test_public_room(self):
         """Tests that it's not possible to have a room with the public join rule and an
@@ -649,10 +694,7 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
             content["initial_state"] += initial_state
 
         request, channel = self.make_request(
-            "POST",
-            "/_matrix/client/r0/createRoom",
-            json.dumps(content),
-            access_token=self.tok,
+            "POST", "/_matrix/client/r0/createRoom", content, access_token=self.tok,
         )
         self.render(request)
 


### PR DESCRIPTION
This PR modifies the `RoomAccessRules` module, an implementation of `ThirdPartyEventRules`, to both:

* Modify the default power levels when creating a room to set:
  - `invite` to be minimum PL50
  - `state_default` to be minimum PL100
* Enforce this when creating the room.

Reviewable commit-by-commit.