### PR TITLE
RoomAccessRules cleanup

### DIFF
--- a/changelog.d/62.misc
+++ b/changelog.d/62.misc
@@ -1,0 +1,1 @@
+Type hinting and other cleanups for `synapse.third_party_rules.access_rules`.

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -333,10 +333,9 @@ class RoomAccessRules(object):
         prev_rule = prev_rules_event.content.get("rule")
 
         # Currently, we can only go from "restricted" to "unrestricted".
-        if prev_rule == ACCESS_RULE_RESTRICTED and new_rule == ACCESS_RULE_UNRESTRICTED:
-            return True
-
-        return False
+        return (
+            prev_rule == ACCESS_RULE_RESTRICTED and new_rule == ACCESS_RULE_UNRESTRICTED
+        )
 
     def _on_membership_or_invite(
         self,

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -217,20 +217,20 @@ class RoomAccessRules(object):
         rule = self._get_rule_from_state(state_events)
 
         if medium != "email":
-            defer.returnValue(False)
+            return False
 
         if rule != ACCESS_RULE_RESTRICTED:
             # Only "restricted" requires filtering 3PID invites. We don't need to do
             # anything for "direct" here, because only "restricted" requires filtering
             # based on the HS the address is mapped to.
-            defer.returnValue(True)
+            return True
 
         parsed_address = email.utils.parseaddr(address)[1]
         if parsed_address != address:
             # Avoid reproducing the security issue described here:
             # https://matrix.org/blog/2019/04/18/security-update-sydent-1-0-2
             # It's probably not worth it but let's just be overly safe here.
-            defer.returnValue(False)
+            return False
 
         # Get the HS this address belongs to from the identity server.
         res = yield self.http_client.get_json(
@@ -240,11 +240,11 @@ class RoomAccessRules(object):
 
         # Look for a domain that's not forbidden from being invited.
         if not res.get("hs"):
-            defer.returnValue(False)
+            return False
         if res.get("hs") in self.domains_forbidden_when_restricted:
-            defer.returnValue(False)
+            return False
 
-        defer.returnValue(True)
+        return True
 
     def check_event_allowed(
         self, event: EventBase, state_events: Dict[Tuple[str, str], EventBase],

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -263,7 +263,7 @@ class RoomAccessRules(object):
                 State events in the room the event originated from.
 
         Returns:
-            Whether the event is allowed.
+            True if the event can be allowed, False otherwise.
         """
         if event.type == ACCESS_RULES_TYPE:
             return self._on_rules_change(event, state_events)
@@ -303,7 +303,7 @@ class RoomAccessRules(object):
                 State events in the room before the event was sent.
 
         Returns:
-            Whether the event is allowed.
+            True if the event can be allowed, False otherwise.
         """
         new_rule = event.content.get("rule")
 
@@ -353,7 +353,7 @@ class RoomAccessRules(object):
                 The state of the room before the event was sent.
 
         Returns:
-            Whether the event is allowed.
+            True if the event can be allowed, False otherwise.
         """
         if rule == AccessRules.RESTRICTED:
             ret = self._on_membership_or_invite_restricted(event)
@@ -378,7 +378,7 @@ class RoomAccessRules(object):
             event: The event to check.
 
         Returns:
-            Whether the event is allowed.
+            True if the event can be allowed, False otherwise.
         """
         # We're not applying the rules on m.room.third_party_member events here because
         # the filtering on threepids is done in check_threepid_can_be_invited, which is
@@ -402,7 +402,7 @@ class RoomAccessRules(object):
         "unrestricted" currently means that every event is allowed.
 
         Returns:
-            Whether the event is allowed.
+            True if the event can be allowed, False otherwise.
         """
         return True
 
@@ -420,7 +420,7 @@ class RoomAccessRules(object):
                 The state of the room before the event was sent.
 
         Returns:
-            Whether the event is allowed.
+            True if the event can be allowed, False otherwise.
         """
         # Get the room memberships and 3PID invite tokens from the room's state.
         existing_members, threepid_tokens = self._get_members_and_tokens_from_state(
@@ -543,7 +543,7 @@ class RoomAccessRules(object):
             rule: The name of the rule to apply.
 
         Returns:
-            Whether the event is allowed.
+            True if the event can be allowed, False otherwise.
         """
         return rule != AccessRules.DIRECT
 
@@ -557,7 +557,7 @@ class RoomAccessRules(object):
             rule: The name of the rule to apply.
 
         Returns:
-            Whether the event is allowed.
+            True if the event can be allowed, False otherwise.
         """
         return rule != AccessRules.DIRECT
 
@@ -571,7 +571,7 @@ class RoomAccessRules(object):
             rule: The name of the rule to apply.
 
         Returns:
-            Whether the event is allowed.
+            True if the event can be allowed, False otherwise.
         """
         return rule != AccessRules.DIRECT
 

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -22,7 +22,7 @@ from synapse.api.errors import SynapseError
 from synapse.config._base import ConfigError
 from synapse.events import EventBase
 from synapse.http.client import SimpleHttpClient
-from synapse.types import Requester, get_domain_from_id
+from synapse.types import Requester, StateMap, get_domain_from_id
 
 ACCESS_RULES_TYPE = "im.vector.room.access_rules"
 
@@ -200,7 +200,7 @@ class RoomAccessRules(object):
 
     @defer.inlineCallbacks
     def check_threepid_can_be_invited(
-        self, medium: str, address: str, state_events: Dict[Tuple[str, str], EventBase],
+        self, medium: str, address: str, state_events: StateMap[EventBase],
     ) -> bool:
         """Implements synapse.events.ThirdPartyEventRules.check_threepid_can_be_invited.
 
@@ -250,7 +250,7 @@ class RoomAccessRules(object):
         return True
 
     def check_event_allowed(
-        self, event: EventBase, state_events: Dict[Tuple[str, str], EventBase],
+        self, event: EventBase, state_events: StateMap[EventBase],
     ) -> bool:
         """Implements synapse.events.ThirdPartyEventRules.check_event_allowed.
 
@@ -292,7 +292,7 @@ class RoomAccessRules(object):
         return True
 
     def _on_rules_change(
-        self, event: EventBase, state_events: Dict[Tuple[str, str], EventBase],
+        self, event: EventBase, state_events: StateMap[EventBase],
     ) -> bool:
         """Implement the checks and behaviour specified on allowing or forbidding a new
         im.vector.room.access_rules event.
@@ -341,10 +341,7 @@ class RoomAccessRules(object):
         )
 
     def _on_membership_or_invite(
-        self,
-        event: EventBase,
-        rule: str,
-        state_events: Dict[Tuple[str, str], EventBase],
+        self, event: EventBase, rule: str, state_events: StateMap[EventBase],
     ) -> bool:
         """Applies the correct rule for incoming m.room.member and
         m.room.third_party_invite events.
@@ -410,7 +407,7 @@ class RoomAccessRules(object):
         return True
 
     def _on_membership_or_invite_direct(
-        self, event: EventBase, state_events: Dict[Tuple[str, str], EventBase],
+        self, event: EventBase, state_events: StateMap[EventBase],
     ) -> bool:
         """Implements the checks and behaviour specified for the "direct" rule.
 
@@ -579,9 +576,7 @@ class RoomAccessRules(object):
         return rule != AccessRules.DIRECT
 
     @staticmethod
-    def _get_rule_from_state(
-        state_events: Dict[Tuple[str, str], EventBase]
-    ) -> Optional[str]:
+    def _get_rule_from_state(state_events: StateMap[EventBase]) -> Optional[str]:
         """Extract the rule to be applied from the given set of state events.
 
         Args:
@@ -598,9 +593,7 @@ class RoomAccessRules(object):
         return access_rules.content.get("rule")
 
     @staticmethod
-    def _get_join_rule_from_state(
-        state_events: Dict[Tuple[str, str], EventBase]
-    ) -> Optional[str]:
+    def _get_join_rule_from_state(state_events: StateMap[EventBase]) -> Optional[str]:
         """Extract the room's join rule from the given set of state events.
 
         Args:
@@ -618,7 +611,7 @@ class RoomAccessRules(object):
 
     @staticmethod
     def _get_members_and_tokens_from_state(
-        state_events: Dict[Tuple[str, str], EventBase],
+        state_events: StateMap[EventBase],
     ) -> Tuple[List[str], List[str]]:
         """Retrieves the list of users that have a m.room.member event in the room,
         as well as 3PID invites tokens in the room.

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 import json
 import random
 import string
@@ -25,12 +23,7 @@ from twisted.internet import defer
 from synapse.api.constants import EventTypes, JoinRules, RoomCreationPreset
 from synapse.rest import admin
 from synapse.rest.client.v1 import login, room
-from synapse.third_party_rules.access_rules import (
-    ACCESS_RULE_DIRECT,
-    ACCESS_RULE_RESTRICTED,
-    ACCESS_RULE_UNRESTRICTED,
-    ACCESS_RULES_TYPE,
-)
+from synapse.third_party_rules.access_rules import ACCESS_RULES_TYPE, AccessRules
 
 from tests import unittest
 
@@ -109,7 +102,7 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         self.tok = self.login("kermit", "monkey")
 
         self.restricted_room = self.create_room()
-        self.unrestricted_room = self.create_room(rule=ACCESS_RULE_UNRESTRICTED)
+        self.unrestricted_room = self.create_room(rule=AccessRules.UNRESTRICTED)
         self.direct_rooms = [
             self.create_room(direct=True),
             self.create_room(direct=True),
@@ -127,34 +120,34 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         )
 
     def test_create_room_no_rule(self):
-        """Tests that creating a room with no rule will set the default value."""
+        """Tests that creating a room with no rule will set the default."""
         room_id = self.create_room()
         rule = self.current_rule_in_room(room_id)
 
-        self.assertEqual(rule, ACCESS_RULE_RESTRICTED)
+        self.assertEqual(rule, AccessRules.RESTRICTED)
 
     def test_create_room_direct_no_rule(self):
-        """Tests that creating a direct room with no rule will set the default value."""
+        """Tests that creating a direct room with no rule will set the default."""
         room_id = self.create_room(direct=True)
         rule = self.current_rule_in_room(room_id)
 
-        self.assertEqual(rule, ACCESS_RULE_DIRECT)
+        self.assertEqual(rule, AccessRules.DIRECT)
 
     def test_create_room_valid_rule(self):
-        """Tests that creating a room with a valid rule will set the right value."""
-        room_id = self.create_room(rule=ACCESS_RULE_UNRESTRICTED)
+        """Tests that creating a room with a valid rule will set the right."""
+        room_id = self.create_room(rule=AccessRules.UNRESTRICTED)
         rule = self.current_rule_in_room(room_id)
 
-        self.assertEqual(rule, ACCESS_RULE_UNRESTRICTED)
+        self.assertEqual(rule, AccessRules.UNRESTRICTED)
 
     def test_create_room_invalid_rule(self):
         """Tests that creating a room with an invalid rule will set fail."""
-        self.create_room(rule=ACCESS_RULE_DIRECT, expected_code=400)
+        self.create_room(rule=AccessRules.DIRECT, expected_code=400)
 
     def test_create_room_direct_invalid_rule(self):
         """Tests that creating a direct room with an invalid rule will fail.
         """
-        self.create_room(direct=True, rule=ACCESS_RULE_RESTRICTED, expected_code=400)
+        self.create_room(direct=True, rule=AccessRules.RESTRICTED, expected_code=400)
 
     def test_public_room(self):
         """Tests that it's not possible to have a room with the public join rule and an
@@ -164,7 +157,7 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         # rule to restricted.
         preset_room_id = self.create_room(preset=RoomCreationPreset.PUBLIC_CHAT)
         self.assertEqual(
-            self.current_rule_in_room(preset_room_id), ACCESS_RULE_RESTRICTED
+            self.current_rule_in_room(preset_room_id), AccessRules.RESTRICTED
         )
 
         # Creating a room with the public join rule in its initial state should succeed
@@ -178,21 +171,21 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
             ]
         )
         self.assertEqual(
-            self.current_rule_in_room(init_state_room_id), ACCESS_RULE_RESTRICTED
+            self.current_rule_in_room(init_state_room_id), AccessRules.RESTRICTED
         )
 
         # Changing access rule to unrestricted should fail.
         self.change_rule_in_room(
-            preset_room_id, ACCESS_RULE_UNRESTRICTED, expected_code=403
+            preset_room_id, AccessRules.UNRESTRICTED, expected_code=403
         )
         self.change_rule_in_room(
-            init_state_room_id, ACCESS_RULE_UNRESTRICTED, expected_code=403
+            init_state_room_id, AccessRules.UNRESTRICTED, expected_code=403
         )
 
         # Changing access rule to direct should fail.
-        self.change_rule_in_room(preset_room_id, ACCESS_RULE_DIRECT, expected_code=403)
+        self.change_rule_in_room(preset_room_id, AccessRules.DIRECT, expected_code=403)
         self.change_rule_in_room(
-            init_state_room_id, ACCESS_RULE_DIRECT, expected_code=403
+            init_state_room_id, AccessRules.DIRECT, expected_code=403
         )
 
         # Changing join rule to public in an unrestricted room should fail.
@@ -208,12 +201,12 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         # restricted should fail.
         self.create_room(
             preset=RoomCreationPreset.PUBLIC_CHAT,
-            rule=ACCESS_RULE_UNRESTRICTED,
+            rule=AccessRules.UNRESTRICTED,
             expected_code=400,
         )
         self.create_room(
             preset=RoomCreationPreset.PUBLIC_CHAT,
-            rule=ACCESS_RULE_DIRECT,
+            rule=AccessRules.DIRECT,
             expected_code=400,
         )
 
@@ -226,7 +219,7 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
                     "content": {"join_rule": JoinRules.PUBLIC},
                 }
             ],
-            rule=ACCESS_RULE_UNRESTRICTED,
+            rule=AccessRules.UNRESTRICTED,
             expected_code=400,
         )
         self.create_room(
@@ -236,7 +229,7 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
                     "content": {"join_rule": JoinRules.PUBLIC},
                 }
             ],
-            rule=ACCESS_RULE_DIRECT,
+            rule=AccessRules.DIRECT,
             expected_code=400,
         )
 
@@ -446,40 +439,40 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         # We can change the rule from restricted to unrestricted.
         self.change_rule_in_room(
             room_id=self.restricted_room,
-            new_rule=ACCESS_RULE_UNRESTRICTED,
+            new_rule=AccessRules.UNRESTRICTED,
             expected_code=200,
         )
 
         # We can't change the rule from restricted to direct.
         self.change_rule_in_room(
-            room_id=self.restricted_room, new_rule=ACCESS_RULE_DIRECT, expected_code=403
+            room_id=self.restricted_room, new_rule=AccessRules.DIRECT, expected_code=403
         )
 
         # We can't change the rule from unrestricted to restricted.
         self.change_rule_in_room(
             room_id=self.unrestricted_room,
-            new_rule=ACCESS_RULE_RESTRICTED,
+            new_rule=AccessRules.RESTRICTED,
             expected_code=403,
         )
 
         # We can't change the rule from unrestricted to direct.
         self.change_rule_in_room(
             room_id=self.unrestricted_room,
-            new_rule=ACCESS_RULE_DIRECT,
+            new_rule=AccessRules.DIRECT,
             expected_code=403,
         )
 
         # We can't change the rule from direct to restricted.
         self.change_rule_in_room(
             room_id=self.direct_rooms[0],
-            new_rule=ACCESS_RULE_RESTRICTED,
+            new_rule=AccessRules.RESTRICTED,
             expected_code=403,
         )
 
         # We can't change the rule from direct to unrestricted.
         self.change_rule_in_room(
             room_id=self.direct_rooms[0],
-            new_rule=ACCESS_RULE_UNRESTRICTED,
+            new_rule=AccessRules.UNRESTRICTED,
             expected_code=403,
         )
 


### PR DESCRIPTION
Various cleanups of the DINUM-specific `RoomAccessRules` module, including:

* Type hints
* Docstring cleanups
* Some code cleanups

I want to leave the `async`ing until we do another round of merging Synapse `master` into `dinsic`, as `ThirdPartyEventRules` is not async yet on the `dinsic` branch.

Reviewable commit-by-commit, though the bulk of the cleanup is in the first and last commits.