### PR TITLE
Make AccessRules use the public rooms directory instead of checking a room's join rules on rule change

### DIFF
--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -75,6 +75,70 @@ for example:
      wget https://packages.matrix.org/debian/pool/main/m/matrix-synapse-py3/matrix-synapse-py3_1.3.0+stretch1_amd64.deb
      dpkg -i matrix-synapse-py3_1.3.0+stretch1_amd64.deb
 
+Upgrading to v1.21.0
+====================
+
+Forwarding ``/_synapse/client`` through your reverse proxy
+----------------------------------------------------------
+
+The `reverse proxy documentation
+<https://github.com/matrix-org/synapse/blob/develop/docs/reverse_proxy.md>`_ has been updated
+to include reverse proxy directives for ``/_synapse/client/*`` endpoints. As the user password
+reset flow now uses endpoints under this prefix, **you must update your reverse proxy
+configurations for user password reset to work**.
+
+Additionally, note that the `Synapse worker documentation
+<https://github.com/matrix-org/synapse/blob/develop/docs/workers.md>`_ has been updated to
+ state that the ``/_synapse/client/password_reset/email/submit_token`` endpoint can be handled
+by all workers. If you make use of Synapse's worker feature, please update your reverse proxy
+configuration to reflect this change.
+
+New HTML templates
+------------------
+
+A new HTML template,
+`password_reset_confirmation.html <https://github.com/matrix-org/synapse/blob/develop/synapse/res/templates/password_reset_confirmation.html>`_,
+has been added to the ``synapse/res/templates`` directory. If you are using a
+custom template directory, you may want to copy the template over and modify it.
+
+Note that as of v1.20.0, templates do not need to be included in custom template
+directories for Synapse to start. The default templates will be used if a custom
+template cannot be found.
+
+This page will appear to the user after clicking a password reset link that has
+been emailed to them.
+
+To complete password reset, the page must include a way to make a `POST`
+request to
+``/_synapse/client/password_reset/{medium}/submit_token``
+with the query parameters from the original link, presented as a URL-encoded form. See the file
+itself for more details.
+
+Updated Single Sign-on HTML Templates
+-------------------------------------
+
+The ``saml_error.html`` template was removed from Synapse and replaced with the
+``sso_error.html`` template. If your Synapse is configured to use SAML and a
+custom ``sso_redirect_confirm_template_dir`` configuration then any customisations
+of the ``saml_error.html`` template will need to be merged into the ``sso_error.html``
+template. These templates are similar, but the parameters are slightly different:
+
+* The ``msg`` parameter should be renamed to ``error_description``.
+* There is no longer a ``code`` parameter for the response code.
+* A string ``error`` parameter is available that includes a short hint of why a
+  user is seeing the error page.
+
+ThirdPartyEventRules breaking changes
+-------------------------------------
+
+This release introduces a backwards-incompatible change to modules making use of
+`ThirdPartyEventRules` in Synapse.
+
+The `http_client` argument is no longer passed to modules as they are initialised. Instead,
+modules are expected to make use of the `http_client` property on the `ModuleApi` class.
+Modules are now passed a `module_api` argument during initialisation, which is an instance of
+`ModuleApi`.
+
 Upgrading to v1.18.0
 ====================
 

--- a/changelog.d/63.feature
+++ b/changelog.d/63.feature
@@ -1,0 +1,1 @@
+Make AccessRules use the public rooms directory instead of checking a room's join rules on rule change.

--- a/synapse/events/third_party_rules.py
+++ b/synapse/events/third_party_rules.py
@@ -12,8 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Callable
 
 from twisted.internet import defer
+
+from synapse.events import EventBase
+from synapse.module_api import ModuleApi
+from synapse.types import StateMap
 
 
 class ThirdPartyEventRules(object):
@@ -36,7 +41,7 @@ class ThirdPartyEventRules(object):
 
         if module is not None:
             self.third_party_rules = module(
-                config=config, http_client=hs.get_simple_http_client()
+                config=config, module_api=ModuleApi(hs, hs.get_auth_handler()),
             )
 
     @defer.inlineCallbacks
@@ -85,8 +90,7 @@ class ThirdPartyEventRules(object):
         )
         return ret
 
-    @defer.inlineCallbacks
-    def check_threepid_can_be_invited(self, medium, address, room_id):
+    async def check_threepid_can_be_invited(self, medium, address, room_id):
         """Check if a provided 3PID can be invited in the given room.
 
         Args:
@@ -101,14 +105,51 @@ class ThirdPartyEventRules(object):
         if self.third_party_rules is None:
             return True
 
-        state_ids = yield self.store.get_filtered_current_state_ids(room_id)
-        room_state_events = yield self.store.get_events(state_ids.values())
+        state_events = await self._get_state_map_for_room(room_id)
+
+        ret = await self.third_party_rules.check_threepid_can_be_invited(
+            medium, address, state_events
+        )
+        return ret
+
+    async def check_visibility_can_be_modified(
+        self, room_id: str, new_visibility: str
+    ) -> bool:
+        """Check if a room is allowed to be published to, or removed from, the public room
+        list.
+
+        Args:
+            room_id: The ID of the room.
+            new_visibility: The new visibility state. Either "public" or "private".
+
+        Returns:
+            True if the room's visibility can be modified, False if not.
+        """
+        if self.third_party_rules is None:
+            return True
+
+        check_func = getattr(self.third_party_rules, "check_visibility_can_be_modified")
+        if not check_func or not isinstance(check_func, Callable):
+            return True
+
+        state_events = await self._get_state_map_for_room(room_id)
+
+        return await check_func(room_id, state_events, new_visibility)
+
+    async def _get_state_map_for_room(self, room_id: str) -> StateMap[EventBase]:
+        """Given a room ID, return the state events of that room.
+
+        Args:
+            room_id: The ID of the room.
+
+        Returns:
+            A dict mapping (event type, state key) to state event.
+        """
+        state_ids = await self.store.get_filtered_current_state_ids(room_id)
+        room_state_events = await self.store.get_events(state_ids.values())
 
         state_events = {}
         for key, event_id in state_ids.items():
             state_events[key] = room_state_events[event_id]
 
-        ret = yield self.third_party_rules.check_threepid_can_be_invited(
-            medium, address, state_events
-        )
-        return ret
+        return state_events

--- a/synapse/events/third_party_rules.py
+++ b/synapse/events/third_party_rules.py
@@ -44,8 +44,7 @@ class ThirdPartyEventRules(object):
                 config=config, module_api=ModuleApi(hs, hs.get_auth_handler()),
             )
 
-    @defer.inlineCallbacks
-    def check_event_allowed(self, event, context):
+    async def check_event_allowed(self, event, context):
         """Check if a provided event should be allowed in the given context.
 
         Args:
@@ -58,14 +57,14 @@ class ThirdPartyEventRules(object):
         if self.third_party_rules is None:
             return True
 
-        prev_state_ids = yield context.get_prev_state_ids()
+        prev_state_ids = await context.get_prev_state_ids()
 
         # Retrieve the state events from the database.
         state_events = {}
         for key, event_id in prev_state_ids.items():
-            state_events[key] = yield self.store.get_event(event_id, allow_none=True)
+            state_events[key] = await self.store.get_event(event_id, allow_none=True)
 
-        ret = yield self.third_party_rules.check_event_allowed(event, state_events)
+        ret = await self.third_party_rules.check_event_allowed(event, state_events)
         return ret
 
     @defer.inlineCallbacks

--- a/synapse/events/third_party_rules.py
+++ b/synapse/events/third_party_rules.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 from typing import Callable
 
-from twisted.internet import defer
-
 from synapse.events import EventBase
 from synapse.module_api import ModuleApi
 from synapse.types import StateMap
@@ -67,8 +65,7 @@ class ThirdPartyEventRules(object):
         ret = await self.third_party_rules.check_event_allowed(event, state_events)
         return ret
 
-    @defer.inlineCallbacks
-    def on_create_room(self, requester, config, is_requester_admin):
+    async def on_create_room(self, requester, config, is_requester_admin):
         """Intercept requests to create room to allow, deny or update the
         request config.
 
@@ -84,7 +81,7 @@ class ThirdPartyEventRules(object):
         if self.third_party_rules is None:
             return True
 
-        ret = yield self.third_party_rules.on_create_room(
+        ret = await self.third_party_rules.on_create_room(
             requester, config, is_requester_admin
         )
         return ret

--- a/synapse/handlers/directory.py
+++ b/synapse/handlers/directory.py
@@ -45,6 +45,7 @@ class DirectoryHandler(BaseHandler):
         self.config = hs.config
         self.enable_room_list_search = hs.config.enable_room_list_search
         self.require_membership = hs.config.require_membership_for_aliases
+        self.third_party_event_rules = hs.get_third_party_event_rules()
 
         self.federation = hs.get_federation_client()
         hs.get_federation_registry().register_query_handler(
@@ -446,6 +447,15 @@ class DirectoryHandler(BaseHandler):
                 # Lets just return a generic message, as there may be all sorts of
                 # reasons why we said no. TODO: Allow configurable error messages
                 # per alias creation rule?
+                raise SynapseError(403, "Not allowed to publish room")
+
+            # Check if publishing is blocked by a third party module
+            allowed_by_third_party_rules = await (
+                self.third_party_event_rules.check_visibility_can_be_modified(
+                    room_id, visibility
+                )
+            )
+            if not allowed_by_third_party_rules:
                 raise SynapseError(403, "Not allowed to publish room")
 
         await self.store.set_room_is_public(room_id, making_public)

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -660,6 +660,15 @@ class RoomCreationHandler(BaseHandler):
             creator_id=user_id, is_public=is_public, room_version=room_version,
         )
 
+        # Check whether this visibility value is blocked by a third party module
+        allowed_by_third_party_rules = await (
+            self.third_party_event_rules.check_visibility_can_be_modified(
+                room_id, visibility
+            )
+        )
+        if not allowed_by_third_party_rules:
+            raise SynapseError(403, "Room visibility value not allowed.")
+
         directory_handler = self.hs.get_handlers().directory_handler
         if room_alias:
             await directory_handler.create_association(

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -481,6 +481,8 @@ class RoomAccessRules(object):
     ) -> bool:
         """Implements the checks and behaviour specified for the "unrestricted" rule.
 
+        "unrestricted" currently means that forbidden users cannot join without an invite.
+
         Returns:
             True if the event can be allowed, False otherwise.
         """
@@ -757,7 +759,7 @@ class RoomAccessRules(object):
         """Checks whether a given user has been invited to a room
 
         A user has an invite for a room if its state contains a `m.room.member`
-        event with membership type "invite" and their user ID as the state key.
+        event with membership "invite" and their user ID as the state key.
 
         Args:
             user_id: The user to check.

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -395,7 +395,9 @@ class RoomAccessRules(object):
         if new_rule != AccessRules.RESTRICTED:
             # Block this change if this room is currently listed in the public rooms
             # directory
-            if await self.module_api.room_is_in_public_directory(event.room_id):
+            if await self.module_api.public_room_list_manager.room_is_in_public_room_list(
+                event.room_id
+            ):
                 return False
 
         prev_rules_event = state_events.get((ACCESS_RULES_TYPE, ""))

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -357,7 +357,7 @@ class RoomAccessRules(object):
         # We need to know the rule to apply when processing the event types below.
         rule = self._get_rule_from_state(state_events)
 
-        # Deny adding a room to the public rooms list if it is not restricted
+        # Allow adding a room to the public rooms list only if it is restricted
         if new_visibility == "public":
             return rule == AccessRules.RESTRICTED
 

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -481,8 +481,6 @@ class RoomAccessRules(object):
     ) -> bool:
         """Implements the checks and behaviour specified for the "unrestricted" rule.
 
-        "unrestricted" currently means that every event is allowed.
-
         Returns:
             True if the event can be allowed, False otherwise.
         """
@@ -619,18 +617,6 @@ class RoomAccessRules(object):
 
         A join rule change is always allowed unless the new join rule is "public" and
         the current access rule is "direct".
-
-        The rationale is that external users (those whose server would be denied access
-        to rooms enforcing the "restricted" access rule) should always rely on non-
-        external users for access to rooms, therefore they shouldn't be able to access
-        rooms that don't require an invite to be joined.
-
-        Note that we currently rely on the default access rule being "restricted": during
-        room creation, the m.room.join_rules event will be sent *before* the
-        im.vector.room.access_rules one, so the access rule that will be considered here
-        in this case will be the default "restricted" one. This is fine since the
-        "restricted" access rule allows any value for the join rule, but we should keep
-        that in mind if we need to change the default access rule in the future
 
         Args:
             event: The event to check.
@@ -770,8 +756,8 @@ class RoomAccessRules(object):
     ) -> bool:
         """Checks whether a given user has been invited to a room
 
-        A user has an invite for a room if there is a membership event of type "invite"
-        with their user ID as the state key contained in the room state.
+        A user has an invite for a room if its state contains a `m.room.member`
+        event with membership type "invite" and their user ID as the state key.
 
         Args:
             user_id: The user to check.
@@ -780,11 +766,11 @@ class RoomAccessRules(object):
         Returns:
             True if the user has been invited to the room, or False if they haven't.
         """
-        for state_event in state_events:
+        for (event_type, state_key), state_event in state_events.items():
             if (
-                state_event.type == EventTypes.Member
+                event_type == EventTypes.Member
+                and state_key == user_id
                 and state_event.membership == Membership.INVITE
-                and state_event.state_key == user_id
             ):
                 return True
 

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -22,7 +22,7 @@ from synapse.api.errors import SynapseError
 from synapse.config._base import ConfigError
 from synapse.events import EventBase
 from synapse.module_api import ModuleApi
-from synapse.types import Requester, StateMap, UserID, get_domain_from_id
+from synapse.types import Requester, StateMap, get_domain_from_id
 
 ACCESS_RULES_TYPE = "im.vector.room.access_rules"
 
@@ -490,8 +490,8 @@ class RoomAccessRules(object):
         # room, then deny it
         if event.type == EventTypes.Member and event.membership == Membership.JOIN:
             # Check if this user is from a forbidden server
-            target_user = UserID.from_string(event.state_key)
-            if target_user.domain in self.domains_forbidden_when_restricted:
+            target_domain = get_domain_from_id(event.state_key)
+            if target_domain in self.domains_forbidden_when_restricted:
                 # If so, they'll need an invite to join this room. Check if one exists
                 if not self._user_is_invited_to_room(event.state_key, state_events):
                     return False

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -71,24 +71,38 @@ class ModuleApiTestCase(HomeserverTestCase):
 
         # The room should not currently be in the public rooms directory
         is_in_public_rooms = self.get_success(
-            self.module_api.room_is_in_public_directory(room_id)
+            self.module_api.public_room_list_manager.room_is_in_public_room_list(
+                room_id
+            )
         )
         self.assertFalse(is_in_public_rooms)
 
         # Let's try adding it to the public rooms directory
-        self.get_success(self.module_api.add_room_to_public_directory(room_id))
+        self.get_success(
+            self.module_api.public_room_list_manager.add_room_to_public_room_list(
+                room_id
+            )
+        )
 
         # And checking whether it's in there...
         is_in_public_rooms = self.get_success(
-            self.module_api.room_is_in_public_directory(room_id)
+            self.module_api.public_room_list_manager.room_is_in_public_room_list(
+                room_id
+            )
         )
         self.assertTrue(is_in_public_rooms)
 
         # Let's remove it again
-        self.get_success(self.module_api.remove_room_from_public_directory(room_id))
+        self.get_success(
+            self.module_api.public_room_list_manager.remove_room_from_public_room_list(
+                room_id
+            )
+        )
 
         # Should be gone
         is_in_public_rooms = self.get_success(
-            self.module_api.room_is_in_public_directory(room_id)
+            self.module_api.public_room_list_manager.room_is_in_public_room_list(
+                room_id
+            )
         )
         self.assertFalse(is_in_public_rooms)

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -71,38 +71,24 @@ class ModuleApiTestCase(HomeserverTestCase):
 
         # The room should not currently be in the public rooms directory
         is_in_public_rooms = self.get_success(
-            self.module_api.public_room_list_manager.room_is_in_public_room_list(
-                room_id
-            )
+            self.module_api.room_is_in_public_directory(room_id)
         )
         self.assertFalse(is_in_public_rooms)
 
         # Let's try adding it to the public rooms directory
-        self.get_success(
-            self.module_api.public_room_list_manager.add_room_to_public_room_list(
-                room_id
-            )
-        )
+        self.get_success(self.module_api.add_room_to_public_directory(room_id))
 
         # And checking whether it's in there...
         is_in_public_rooms = self.get_success(
-            self.module_api.public_room_list_manager.room_is_in_public_room_list(
-                room_id
-            )
+            self.module_api.room_is_in_public_directory(room_id)
         )
         self.assertTrue(is_in_public_rooms)
 
         # Let's remove it again
-        self.get_success(
-            self.module_api.public_room_list_manager.remove_room_from_public_room_list(
-                room_id
-            )
-        )
+        self.get_success(self.module_api.remove_room_from_public_directory(room_id))
 
         # Should be gone
         is_in_public_rooms = self.get_success(
-            self.module_api.public_room_list_manager.room_is_in_public_room_list(
-                room_id
-            )
+            self.module_api.room_is_in_public_directory(room_id)
         )
         self.assertFalse(is_in_public_rooms)

--- a/tests/module_api/test_api.py
+++ b/tests/module_api/test_api.py
@@ -12,13 +12,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from synapse.module_api import ModuleApi
+from synapse.rest import admin
+from synapse.rest.client.v1 import login, room
 
 from tests.unittest import HomeserverTestCase
 
 
 class ModuleApiTestCase(HomeserverTestCase):
+    servlets = [
+        admin.register_servlets,
+        login.register_servlets,
+        room.register_servlets,
+    ]
+
     def prepare(self, reactor, clock, homeserver):
         self.store = homeserver.get_datastore()
         self.module_api = ModuleApi(homeserver, homeserver.get_auth_handler())
@@ -52,3 +59,50 @@ class ModuleApiTestCase(HomeserverTestCase):
         # Check that the displayname was assigned
         displayname = self.get_success(self.store.get_profile_displayname("bob"))
         self.assertEqual(displayname, "Bobberino")
+
+    def test_public_rooms(self):
+        """Tests that a room can be added and removed from the public rooms list,
+        as well as have its public rooms directory state queried.
+        """
+        # Create a user and room to play with
+        user_id = self.register_user("kermit", "monkey")
+        tok = self.login("kermit", "monkey")
+        room_id = self.helper.create_room_as(user_id, tok=tok)
+
+        # The room should not currently be in the public rooms directory
+        is_in_public_rooms = self.get_success(
+            self.module_api.public_room_list_manager.room_is_in_public_room_list(
+                room_id
+            )
+        )
+        self.assertFalse(is_in_public_rooms)
+
+        # Let's try adding it to the public rooms directory
+        self.get_success(
+            self.module_api.public_room_list_manager.add_room_to_public_room_list(
+                room_id
+            )
+        )
+
+        # And checking whether it's in there...
+        is_in_public_rooms = self.get_success(
+            self.module_api.public_room_list_manager.room_is_in_public_room_list(
+                room_id
+            )
+        )
+        self.assertTrue(is_in_public_rooms)
+
+        # Let's remove it again
+        self.get_success(
+            self.module_api.public_room_list_manager.remove_room_from_public_room_list(
+                room_id
+            )
+        )
+
+        # Should be gone
+        is_in_public_rooms = self.get_success(
+            self.module_api.public_room_list_manager.room_is_in_public_room_list(
+                room_id
+            )
+        )
+        self.assertFalse(is_in_public_rooms)

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -263,12 +263,7 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         )
 
         # Creating a new room with the public_chat preset and an access rule that isn't
-        # restricted should fail.
-        self.create_room(
-            preset=RoomCreationPreset.PUBLIC_CHAT,
-            rule=AccessRules.UNRESTRICTED,
-            expected_code=400,
-        )
+        # restricted or unrestricted should fail.
         self.create_room(
             preset=RoomCreationPreset.PUBLIC_CHAT,
             rule=AccessRules.DIRECT,

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -731,7 +731,7 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
 
         It tests that:
             * forbidden users cannot join restricted rooms.
-            * forbidden users can join unrestricted rooms if they have an invite.
+            * forbidden users can only join unrestricted rooms if they have an invite.
         """
         event_creator = self.hs.get_event_creation_handler()
 
@@ -784,7 +784,7 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         )
         self.assertTrue(can_join)
 
-        # Test that forbidden users can join unrestricted rooms if they have an invite
+        # Test that forbidden users can only join unrestricted rooms if they have an invite
 
         # Recreate the forbidden join event for the unrestricted room instead
         forbidden_join_event, forbidden_join_event_context = self.get_success(


### PR DESCRIPTION
Requires https://github.com/matrix-org/synapse/pull/8292 over on mainline, which we plan to cherry-pick for now.

This PR makes use of the new public room directory features added to `ThirdPartyEventRules` by the above PR, by:

1. Preventing publishing a room to the public rooms list if it has "unrestricted" access rule, during or after room creation.
2. Preventing a room from changing its access rule to "unrestricted" if it is currently published in the public rooms directory.

When reviewing this PR, it's recommend to skip the first commit, as it's simply the port of the above PR.