### PR TITLE
Swap method calls in RoomAccessTestCase.test_change_rules

### DIFF
--- a/changelog.d/64.bugfix
+++ b/changelog.d/64.bugfix
@@ -1,0 +1,1 @@
+Ensure we don't accidentally modify a room's access rule and then test that room assuming its access rule has not changed.

--- a/changelog.d/64.bugfix
+++ b/changelog.d/64.bugfix
@@ -1,1 +1,1 @@
-Ensure we don't accidentally modify a room's access rule and then test that room assuming its access rule has not changed.
+Ensure a `RoomAccessRules` test doesn't accidentally modify a room's access rule and then test that room assuming its access rule has not changed.

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -492,6 +492,7 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         )
 
         # We can change the rule from restricted to unrestricted.
+        # Note that this changes self.restricted_room to an unrestricted room
         self.change_rule_in_room(
             room_id=self.restricted_room,
             new_rule=AccessRules.UNRESTRICTED,

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -486,16 +486,16 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         """Tests that we can only change the current rule from restricted to
         unrestricted.
         """
+        # We can't change the rule from restricted to direct.
+        self.change_rule_in_room(
+            room_id=self.restricted_room, new_rule=AccessRules.DIRECT, expected_code=403
+        )
+
         # We can change the rule from restricted to unrestricted.
         self.change_rule_in_room(
             room_id=self.restricted_room,
             new_rule=AccessRules.UNRESTRICTED,
             expected_code=200,
-        )
-
-        # We can't change the rule from restricted to direct.
-        self.change_rule_in_room(
-            room_id=self.restricted_room, new_rule=AccessRules.DIRECT, expected_code=403
         )
 
         # We can't change the rule from unrestricted to restricted.


### PR DESCRIPTION
Swap these calls around, as the check for changing `restricted` to `unrestricted` will actually change `self.restricted_room` to an unrestricted room.

Do that last, instead of first. Additionally add a comment with a warning.

Ideally would land after https://github.com/matrix-org/synapse-dinsic/pull/63 as to prevent conflicts.