### PR TITLE
Only assert valid next_link params when provided

### DIFF
--- a/changelog.d/65.bugfix
+++ b/changelog.d/65.bugfix
@@ -1,0 +1,1 @@
+Fix `nextLink` parameters being checked on validation endpoints even if they weren't provided by the client.

--- a/synapse/rest/client/v2_alpha/account.py
+++ b/synapse/rest/client/v2_alpha/account.py
@@ -111,8 +111,9 @@ class EmailPasswordRequestTokenRestServlet(RestServlet):
                 Codes.THREEPID_DENIED,
             )
 
-        # Raise if the provided next_link value isn't valid
-        assert_valid_next_link(self.hs, next_link)
+        if next_link:
+            # Raise if the provided next_link value isn't valid
+            assert_valid_next_link(self.hs, next_link)
 
         # The email will be sent to the stored address.
         # This avoids a potential account hijack by requesting a password reset to
@@ -462,8 +463,9 @@ class EmailThreepidRequestTokenRestServlet(RestServlet):
                 Codes.THREEPID_DENIED,
             )
 
-        # Raise if the provided next_link value isn't valid
-        assert_valid_next_link(self.hs, next_link)
+        if next_link:
+            # Raise if the provided next_link value isn't valid
+            assert_valid_next_link(self.hs, next_link)
 
         existing_user_id = await self.store.get_user_id_by_threepid("email", email)
 
@@ -533,8 +535,9 @@ class MsisdnThreepidRequestTokenRestServlet(RestServlet):
                 Codes.THREEPID_DENIED,
             )
 
-        # Raise if the provided next_link value isn't valid
-        assert_valid_next_link(self.hs, next_link)
+        if next_link:
+            # Raise if the provided next_link value isn't valid
+            assert_valid_next_link(self.hs, next_link)
 
         existing_user_id = await self.store.get_user_id_by_threepid("msisdn", msisdn)
 


### PR DESCRIPTION
Bug introduced in https://github.com/matrix-org/synapse-dinsic/commit/ff91a451b

We were checking whether the `nextLink` param was valid, even if it wasn't provided. In that case, `nextLink` was `None`, which would clearly not be a valid URL.

This would prevent password reset and other operations if `nextLink` was not provided and the `next_link_domain_whitelist` config option was in use.