### PR TITLE
Remember mappings when we bind a 3pid using the internal sydent bind API

### DIFF
--- a/changelog.d/66.bugfix
+++ b/changelog.d/66.bugfix
@@ -1,0 +1,1 @@
+Create a mapping between user ID and threepid when binding via the internal Sydent bind API.

--- a/tests/handlers/test_register.py
+++ b/tests/handlers/test_register.py
@@ -566,6 +566,12 @@ class RegistrationTestCase(unittest.HomeserverTestCase):
             {"address": "alice@example.com", "medium": "email", "mxid": "@alice:test"},
         )
 
+        # Check that we stored a mapping of this bind
+        bound_threepids = self.get_success(
+            self.store.user_get_bound_threepids("@alice:test")
+        )
+        self.assertListEqual(bound_threepids, [{"medium": "email", "address": email}])
+
     def uia_register(self, expected_response: int, body: dict) -> FakeChannel:
         """Make a register request."""
         request, channel = self.make_request(


### PR DESCRIPTION
https://github.com/matrix-org/synapse-dinsic/pull/51 added an option that would automatically bind a user's threepid to a configured identity server after they had registered. Unfortunately, when you bind threepids, ideally you would store that mapping in the database so that later on you can remove those mappings when you deactivate an account.

We found that due the fact that we did not store these mappings, threepids were not unbound upon user account deactivation.

This PR fixes the issue by creating the mappings again, meaning they will again be removed upon account deactivation.