### PR TITLE
Override any missing default power level keys with DINUM's defaults when creating a room

### DIFF
--- a/changelog.d/68.misc
+++ b/changelog.d/68.misc
@@ -1,0 +1,1 @@
+Override any missing default power level keys with DINUM's defaults when creating a room.

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -752,15 +752,15 @@ class RoomAccessRules(object):
             # values should be replaced with our "default" power level values anyways,
             # which are compliant
 
-            # If invite requirements are <PL50
-            if content.get("invite", default_power_levels["invite"]) < 50:
+            invite = default_power_levels["invite"]
+            state_default = default_power_levels["state_default"]
+
+            # If invite requirements are less than our required defaults
+            if content.get("invite", invite) < invite:
                 return False
 
-            # If "other" state requirements are <PL100
-            if (
-                content.get("state_default", default_power_levels["state_default"])
-                < 100
-            ):
+            # If "other" state requirements are less than our required defaults
+            if content.get("state_default", state_default) < state_default:
                 return False
 
         # Check if we need to apply the restrictions with the current rule.

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -326,12 +326,9 @@ class RoomAccessRules(object):
         # We need to know the rule to apply when processing the event types below.
         rule = self._get_rule_from_state(state_events)
 
-        # We also need to know the default power levels as they apply to the sender
-        default_power_levels = self._get_default_power_levels(event.sender)
-
         if event.type == EventTypes.PowerLevels:
             return self._is_power_level_content_allowed(
-                event.content, rule, default_power_levels, on_room_creation=False
+                event.content, rule, on_room_creation=False
             )
 
         if event.type == EventTypes.Member or event.type == EventTypes.ThirdPartyInvite:
@@ -722,7 +719,7 @@ class RoomAccessRules(object):
         self,
         content: Dict,
         access_rule: str,
-        default_power_levels: Dict,
+        default_power_levels: Optional[Dict] = None,
         on_room_creation: bool = True,
     ) -> bool:
         """Check if a given power levels event is permitted under the given access rule.
@@ -735,7 +732,7 @@ class RoomAccessRules(object):
             content: The content of the m.room.power_levels event to check.
             access_rule: The access rule in place in this room.
             default_power_levels: The default power levels when a room is created with
-                the specified access rule.
+                the specified access rule. Required if on_room_creation is True.
             on_room_creation: True if this call is happening during a room's
                 creation, False otherwise.
 


### PR DESCRIPTION
The createRoom flow in DINUM's Synapse (through the AccessRules module which has hooks for all of this) already rejects a power levels content dict if it doesn't have high enough power levels to satisfy DINUM's [requirements](https://github.com/matrix-org/synapse-dinsic/blob/ac50ed353b5fdbdf9f853be0d94b6fccaf33973e/synapse/third_party_rules/access_rules.py#L233-L252).

This PR ensures that any keys that aren't provided are replaced with the defaults, instead of just assuming the whole dict was correct (and thus those keys were set to mainline Synapse's default instead).