### PR TITLE
Update mypy to 0.790 to resolve mypy CI errors

### DIFF
--- a/changelog.d/72.bugfix
+++ b/changelog.d/72.bugfix
@@ -1,0 +1,1 @@
+Update the version of mypy to 0.790.

--- a/changelog.d/8569.misc
+++ b/changelog.d/8569.misc
@@ -1,0 +1,1 @@
+Fix mypy not properly checking across the codebase, additionally, fix a typing assertion error in `handlers/auth.py`.

--- a/changelog.d/8569.misc
+++ b/changelog.d/8569.misc
@@ -1,1 +1,0 @@
-Fix mypy not properly checking across the codebase, additionally, fix a typing assertion error in `handlers/auth.py`.

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -1115,20 +1115,22 @@ class AuthHandler(BaseHandler):
             Whether self.hash(password) == stored_hash.
         """
 
-        def _do_validate_hash():
+        def _do_validate_hash(checked_hash: bytes):
             # Normalise the Unicode in the password
             pw = unicodedata.normalize("NFKC", password)
 
             return bcrypt.checkpw(
                 pw.encode("utf8") + self.hs.config.password_pepper.encode("utf8"),
-                stored_hash,
+                checked_hash,
             )
 
         if stored_hash:
             if not isinstance(stored_hash, bytes):
                 stored_hash = stored_hash.encode("ascii")
 
-            return await defer_to_thread(self.hs.get_reactor(), _do_validate_hash)
+            return await defer_to_thread(
+                self.hs.get_reactor(), _do_validate_hash, stored_hash
+            )
         else:
             return False
 

--- a/synapse/python_dependencies.py
+++ b/synapse/python_dependencies.py
@@ -107,6 +107,8 @@ CONDITIONAL_REQUIREMENTS = {
     "redis": ["txredisapi>=1.4.7", "hiredis"],
 }
 
+CONDITIONAL_REQUIREMENTS["mypy"] = ["mypy==0.790", "mypy-zope==0.2.8"]
+
 ALL_OPTIONAL_REQUIREMENTS = set()  # type: Set[str]
 
 for name, optional_deps in CONDITIONAL_REQUIREMENTS.items():

--- a/tox.ini
+++ b/tox.ini
@@ -159,7 +159,6 @@ commands=
     coverage html
 
 [testenv:mypy]
-skip_install = True
 deps =
     {[base]deps}
 extras = all, mypy

--- a/tox.ini
+++ b/tox.ini
@@ -162,9 +162,7 @@ commands=
 skip_install = True
 deps =
     {[base]deps}
-    mypy==0.782
-    mypy-zope
-extras = all
+extras = all, mypy
 commands = mypy
 
 # To find all folders that pass mypy you run:


### PR DESCRIPTION
The version of `mypy` that was pinned looks to have gotten sufficiently old such that it no longer works with the latest version of `mypy-zope`. Let's bump the pin up to the version upstream is using.

(Going to be looking at CI results here).