### PR TITLE
Allow users to click account renewal links multiple times without hitting an 'Invalid Token' page

### DIFF
--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -1192,69 +1192,6 @@ url_preview_accept_language:
 #
 #enable_registration: false
 
-# Optional account validity configuration. This allows for accounts to be denied
-# any request after a given period.
-#
-# Once this feature is enabled, Synapse will look for registered users without an
-# expiration date at startup and will add one to every account it found using the
-# current settings at that time.
-# This means that, if a validity period is set, and Synapse is restarted (it will
-# then derive an expiration date from the current validity period), and some time
-# after that the validity period changes and Synapse is restarted, the users'
-# expiration dates won't be updated unless their account is manually renewed. This
-# date will be randomly selected within a range [now + period - d ; now + period],
-# where d is equal to 10% of the validity period.
-#
-account_validity:
-  # The account validity feature is disabled by default. Uncomment the
-  # following line to enable it.
-  #
-  #enabled: true
-
-  # The period after which an account is valid after its registration. When
-  # renewing the account, its validity period will be extended by this amount
-  # of time. This parameter is required when using the account validity
-  # feature.
-  #
-  #period: 6w
-
-  # The amount of time before an account's expiry date at which Synapse will
-  # send an email to the account's email address with a renewal link. By
-  # default, no such emails are sent.
-  #
-  # If you enable this setting, you will also need to fill out the 'email' and
-  # 'public_baseurl' configuration sections.
-  #
-  #renew_at: 1w
-
-  # The subject of the email sent out with the renewal link. '%(app)s' can be
-  # used as a placeholder for the 'app_name' parameter from the 'email'
-  # section.
-  #
-  # Note that the placeholder must be written '%(app)s', including the
-  # trailing 's'.
-  #
-  # If this is not set, a default value is used.
-  #
-  #renew_email_subject: "Renew your %(app)s account"
-
-  # Directory in which Synapse will try to find templates for the HTML files to
-  # serve to the user when trying to renew an account. If not set, default
-  # templates from within the Synapse package will be used.
-  #
-  #template_dir: "res/templates"
-
-  # File within 'template_dir' giving the HTML to be displayed to the user after
-  # they successfully renewed their account. If not set, default text is used.
-  #
-  #account_renewed_html_path: "account_renewed.html"
-
-  # File within 'template_dir' giving the HTML to be displayed when the user
-  # tries to renew an account with an invalid renewal token. If not set,
-  # default text is used.
-  #
-  #invalid_token_html_path: "invalid_token.html"
-
 # Time that a user's session remains valid for, after they log in.
 #
 # Note that this is not currently compatible with guest logins.
@@ -1521,6 +1458,72 @@ account_threepid_delegates:
 # without validation.
 #
 #bind_new_user_emails_to_sydent: https://example.com:8091
+
+
+## Account Validity ##
+#
+# Optional account validity configuration. This allows for accounts to be denied
+# any request after a given period.
+#
+# Once this feature is enabled, Synapse will look for registered users without an
+# expiration date at startup and will add one to every account it found using the
+# current settings at that time.
+# This means that, if a validity period is set, and Synapse is restarted (it will
+# then derive an expiration date from the current validity period), and some time
+# after that the validity period changes and Synapse is restarted, the users'
+# expiration dates won't be updated unless their account is manually renewed. This
+# date will be randomly selected within a range [now + period - d ; now + period],
+# where d is equal to 10% of the validity period.
+#
+account_validity:
+  # The account validity feature is disabled by default. Uncomment the
+  # following line to enable it.
+  #
+  #enabled: true
+
+  # The period after which an account is valid after its registration. When
+  # renewing the account, its validity period will be extended by this amount
+  # of time. This parameter is required when using the account validity
+  # feature.
+  #
+  #period: 6w
+
+  # The amount of time before an account's expiry date at which Synapse will
+  # send an email to the account's email address with a renewal link. By
+  # default, no such emails are sent.
+  #
+  # If you enable this setting, you will also need to fill out the 'email' and
+  # 'public_baseurl' configuration sections.
+  #
+  #renew_at: 1w
+
+  # The subject of the email sent out with the renewal link. '%(app)s' can be
+  # used as a placeholder for the 'app_name' parameter from the 'email'
+  # section.
+  #
+  # Note that the placeholder must be written '%(app)s', including the
+  # trailing 's'.
+  #
+  # If this is not set, a default value is used.
+  #
+  #renew_email_subject: "Renew your %(app)s account"
+
+  # Directory in which Synapse will try to find templates for the HTML files to
+  # serve to the user when trying to renew an account. If not set, default
+  # templates from within the Synapse package will be used.
+  #
+  #template_dir: "res/templates"
+
+  # File within 'template_dir' giving the HTML to be displayed to the user after
+  # they successfully renewed their account. If not set, default text is used.
+  #
+  #account_renewed_html_path: "account_renewed.html"
+
+  # File within 'template_dir' giving the HTML to be displayed when the user
+  # tries to renew an account with an invalid renewal token. If not set,
+  # default text is used.
+  #
+  #invalid_token_html_path: "invalid_token.html"
 
 
 ## Metrics ###

--- a/synapse/api/auth.py
+++ b/synapse/api/auth.py
@@ -75,7 +75,7 @@ class Auth:
 
         self._auth_blocking = AuthBlocking(self.hs)
 
-        self._account_validity = hs.config.account_validity
+        self._account_validity_enabled = hs.config.account_validity_enabled
         self._track_appservice_user_ips = hs.config.track_appservice_user_ips
         self._macaroon_secret_key = hs.config.macaroon_secret_key
 
@@ -216,7 +216,7 @@ class Auth:
             shadow_banned = user_info["shadow_banned"]
 
             # Deny the request if the user account has expired.
-            if self._account_validity.enabled and not allow_expired:
+            if self._account_validity_enabled and not allow_expired:
                 user_id = user.to_string()
                 if await self.store.is_account_expired(user_id, self.clock.time_msec()):
                     raise AuthError(

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -244,7 +244,7 @@ class Config:
 
         # Update the environment with our custom filters
         env.filters.update({"format_ts": _format_ts_filter})
-        if self.public_baseurl:
+        if self.root and self.root.public_baseurl:
             env.filters.update(
                 {"mxc_to_http": _create_mxc_to_http_filter(self.public_baseurl)}
             )

--- a/synapse/config/_base.py
+++ b/synapse/config/_base.py
@@ -244,7 +244,7 @@ class Config:
 
         # Update the environment with our custom filters
         env.filters.update({"format_ts": _format_ts_filter})
-        if self.root and self.root.public_baseurl:
+        if self.public_baseurl:
             env.filters.update(
                 {"mxc_to_http": _create_mxc_to_http_filter(self.public_baseurl)}
             )

--- a/synapse/config/_base.pyi
+++ b/synapse/config/_base.pyi
@@ -1,6 +1,7 @@
 from typing import Any, List, Optional
 
 from synapse.config import (
+    account_validity,
     api,
     appservice,
     captcha,
@@ -53,6 +54,7 @@ class RootConfig:
     captcha: captcha.CaptchaConfig
     voip: voip.VoipConfig
     registration: registration.RegistrationConfig
+    account_validity: account_validity.AccountValidityConfig
     metrics: metrics.MetricsConfig
     api: api.ApiConfig
     appservice: appservice.AppServiceConfig

--- a/synapse/config/account_validity.py
+++ b/synapse/config/account_validity.py
@@ -19,7 +19,7 @@ class AccountValidityConfig(Config):
     section = "account_validity"
 
     def read_config(self, config, **kwargs):
-        account_validity_config = config.get("account_validity", {})
+        account_validity_config = config.get("account_validity") or {}
         self.account_validity_enabled = account_validity_config.get("enabled", False)
         self.account_validity_renew_by_email_enabled = (
             "renew_at" in account_validity_config

--- a/synapse/config/account_validity.py
+++ b/synapse/config/account_validity.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from synapse.config._base import Config, ConfigError
+
+
+class AccountValidityConfig(Config):
+    section = "account_validity"
+
+    def read_config(self, config, **kwargs):
+        account_validity_config = config.get("account_validity", {})
+        self.account_validity_enabled = account_validity_config.get("enabled", False)
+        self.account_validity_renew_by_email_enabled = (
+            "renew_at" in account_validity_config
+        )
+
+        if self.account_validity_enabled:
+            if "period" in account_validity_config:
+                self.account_validity_period = self.parse_duration(
+                    account_validity_config["period"]
+                )
+            else:
+                raise ConfigError("'period' is required when using account validity")
+
+            if "renew_at" in account_validity_config:
+                self.account_validity_renew_at = self.parse_duration(
+                    account_validity_config["renew_at"]
+                )
+
+            if "renew_email_subject" in account_validity_config:
+                self.account_validity_renew_email_subject = account_validity_config[
+                    "renew_email_subject"
+                ]
+            else:
+                self.account_validity_renew_email_subject = "Renew your %(app)s account"
+
+            self.account_validity_startup_job_max_delta = (
+                self.account_validity_period * 10.0 / 100.0
+            )
+
+        if self.account_validity_renew_by_email_enabled:
+            if not self.public_baseurl:
+                raise ConfigError("Can't send renewal emails without 'public_baseurl'")
+
+        # Load account validity templates.
+        # We do this here instead of in AccountValidityConfig as read_templates
+        # relies on state that hasn't been initialised in AccountValidityConfig
+        account_renewed_template_filename = account_validity_config.get(
+            "account_renewed_html_path", "account_renewed.html"
+        )
+        account_previously_renewed_template_filename = account_validity_config.get(
+            "account_previously_renewed_html_path", "account_previously_renewed.html"
+        )
+        invalid_token_template_filename = account_validity_config.get(
+            "invalid_token_html_path", "invalid_token.html"
+        )
+        (
+            self.account_validity_account_renewed_template,
+            self.account_validity_account_previously_renewed_template,
+            self.account_validity_invalid_token_template,
+        ) = self.read_templates(
+            [
+                account_renewed_template_filename,
+                account_previously_renewed_template_filename,
+                invalid_token_template_filename,
+            ]
+        )
+
+    def generate_config_section(self, **kwargs):
+        return """\
+        ## Account Validity ##
+        #
+        # Optional account validity configuration. This allows for accounts to be denied
+        # any request after a given period.
+        #
+        # Once this feature is enabled, Synapse will look for registered users without an
+        # expiration date at startup and will add one to every account it found using the
+        # current settings at that time.
+        # This means that, if a validity period is set, and Synapse is restarted (it will
+        # then derive an expiration date from the current validity period), and some time
+        # after that the validity period changes and Synapse is restarted, the users'
+        # expiration dates won't be updated unless their account is manually renewed. This
+        # date will be randomly selected within a range [now + period - d ; now + period],
+        # where d is equal to 10% of the validity period.
+        #
+        account_validity:
+          # The account validity feature is disabled by default. Uncomment the
+          # following line to enable it.
+          #
+          #enabled: true
+
+          # The period after which an account is valid after its registration. When
+          # renewing the account, its validity period will be extended by this amount
+          # of time. This parameter is required when using the account validity
+          # feature.
+          #
+          #period: 6w
+
+          # The amount of time before an account's expiry date at which Synapse will
+          # send an email to the account's email address with a renewal link. By
+          # default, no such emails are sent.
+          #
+          # If you enable this setting, you will also need to fill out the 'email' and
+          # 'public_baseurl' configuration sections.
+          #
+          #renew_at: 1w
+
+          # The subject of the email sent out with the renewal link. '%(app)s' can be
+          # used as a placeholder for the 'app_name' parameter from the 'email'
+          # section.
+          #
+          # Note that the placeholder must be written '%(app)s', including the
+          # trailing 's'.
+          #
+          # If this is not set, a default value is used.
+          #
+          #renew_email_subject: "Renew your %(app)s account"
+
+          # Directory in which Synapse will try to find templates for the HTML files to
+          # serve to the user when trying to renew an account. If not set, default
+          # templates from within the Synapse package will be used.
+          #
+          #template_dir: "res/templates"
+
+          # File within 'template_dir' giving the HTML to be displayed to the user after
+          # they successfully renewed their account. If not set, default text is used.
+          #
+          #account_renewed_html_path: "account_renewed.html"
+
+          # File within 'template_dir' giving the HTML to be displayed when the user
+          # tries to renew an account with an invalid renewal token. If not set,
+          # default text is used.
+          #
+          #invalid_token_html_path: "invalid_token.html"
+        """

--- a/synapse/config/emailconfig.py
+++ b/synapse/config/emailconfig.py
@@ -299,7 +299,7 @@ class EmailConfig(Config):
                 "client_base_url", email_config.get("riot_base_url", None)
             )
 
-        if self.account_validity.renew_by_email_enabled:
+        if self.account_validity_renew_by_email_enabled:
             expiry_template_html = email_config.get(
                 "expiry_template_html", "notice_expiry.html"
             )

--- a/synapse/config/homeserver.py
+++ b/synapse/config/homeserver.py
@@ -13,8 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from ._base import RootConfig
+from .account_validity import AccountValidityConfig
 from .api import ApiConfig
 from .appservice import AppServiceConfig
 from .cache import CacheConfig
@@ -67,6 +67,7 @@ class HomeServerConfig(RootConfig):
         CaptchaConfig,
         VoipConfig,
         RegistrationConfig,
+        AccountValidityConfig,
         MetricsConfig,
         ApiConfig,
         AppServiceConfig,

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -55,14 +55,22 @@ class AccountValidityConfig(Config):
         account_renewed_template_filename = config.get(
             "account_renewed_html_path", "account_renewed.html"
         )
+        account_previously_renewed_template_filename = config.get(
+            "account_previously_renewed_html_path", "account_previously_renewed.html"
+        )
         invalid_token_template_filename = config.get(
             "invalid_token_html_path", "invalid_token.html"
         )
         (
             self.account_renewed_template,
+            self.account_previously_renewed_template,
             self.invalid_token_template,
         ) = self.read_templates(
-            [account_renewed_template_filename, invalid_token_template_filename]
+            [
+                account_renewed_template_filename,
+                account_previously_renewed_template_filename,
+                invalid_token_template_filename,
+            ]
         )
 
 

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -13,10 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from distutils.util import strtobool
-
-import pkg_resources
 
 from synapse.api.constants import RoomCreationPreset
 from synapse.config._base import Config, ConfigError
@@ -54,32 +51,19 @@ class AccountValidityConfig(Config):
             if "public_baseurl" not in synapse_config:
                 raise ConfigError("Can't send renewal emails without 'public_baseurl'")
 
-        template_dir = config.get("template_dir")
-
-        if not template_dir:
-            template_dir = pkg_resources.resource_filename("synapse", "res/templates")
-
-        if "account_renewed_html_path" in config:
-            file_path = os.path.join(template_dir, config["account_renewed_html_path"])
-
-            self.account_renewed_html_content = self.read_file(
-                file_path, "account_validity.account_renewed_html_path"
-            )
-        else:
-            self.account_renewed_html_content = (
-                "<html><body>Your account has been successfully renewed.</body><html>"
-            )
-
-        if "invalid_token_html_path" in config:
-            file_path = os.path.join(template_dir, config["invalid_token_html_path"])
-
-            self.invalid_token_html_content = self.read_file(
-                file_path, "account_validity.invalid_token_html_path"
-            )
-        else:
-            self.invalid_token_html_content = (
-                "<html><body>Invalid renewal token.</body><html>"
-            )
+        # Load templates
+        account_renewed_template_filename = config.get(
+            "account_renewed_html_path", "account_renewed.html"
+        )
+        invalid_token_template_filename = config.get(
+            "invalid_token_html_path", "invalid_token.html"
+        )
+        (
+            self.account_renewed_template,
+            self.invalid_token_template,
+        ) = self.read_templates(
+            [account_renewed_template_filename, invalid_token_template_filename]
+        )
 
 
 class RegistrationConfig(Config):

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -51,28 +51,6 @@ class AccountValidityConfig(Config):
             if "public_baseurl" not in synapse_config:
                 raise ConfigError("Can't send renewal emails without 'public_baseurl'")
 
-        # Load templates
-        account_renewed_template_filename = config.get(
-            "account_renewed_html_path", "account_renewed.html"
-        )
-        account_previously_renewed_template_filename = config.get(
-            "account_previously_renewed_html_path", "account_previously_renewed.html"
-        )
-        invalid_token_template_filename = config.get(
-            "invalid_token_html_path", "invalid_token.html"
-        )
-        (
-            self.account_renewed_template,
-            self.account_previously_renewed_template,
-            self.invalid_token_template,
-        ) = self.read_templates(
-            [
-                account_renewed_template_filename,
-                account_previously_renewed_template_filename,
-                invalid_token_template_filename,
-            ]
-        )
-
 
 class RegistrationConfig(Config):
     section = "registration"
@@ -88,6 +66,30 @@ class RegistrationConfig(Config):
 
         self.account_validity = AccountValidityConfig(
             config.get("account_validity") or {}, config
+        )
+
+        # Load account validity templates.
+        # We do this here instead of in AccountValidityConfig as read_templates
+        # relies on state that hasn't been initialised in AccountValidityConfig
+        account_renewed_template_filename = config.get(
+            "account_renewed_html_path", "account_renewed.html"
+        )
+        account_previously_renewed_template_filename = config.get(
+            "account_previously_renewed_html_path", "account_previously_renewed.html"
+        )
+        invalid_token_template_filename = config.get(
+            "invalid_token_html_path", "invalid_token.html"
+        )
+        (
+            self.account_validity.account_renewed_template,
+            self.account_validity.account_previously_renewed_template,
+            self.account_validity.invalid_token_template,
+        ) = self.read_templates(
+            [
+                account_renewed_template_filename,
+                account_previously_renewed_template_filename,
+                invalid_token_template_filename,
+            ]
         )
 
         self.registrations_require_3pid = config.get("registrations_require_3pid", [])

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -31,6 +31,11 @@ class AccountValidityConfig(Config):
         self.enabled = config.get("enabled", False)
         self.renew_by_email_enabled = "renew_at" in config
 
+        # These are set in RegistrationConfig.read_config
+        self.account_renewed_template = None
+        self.account_previously_renewed_template = None
+        self.invalid_token_template = None
+
         if self.enabled:
             if "period" in config:
                 self.period = self.parse_duration(config["period"])

--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -21,42 +21,6 @@ from synapse.types import RoomAlias, UserID
 from synapse.util.stringutils import random_string_with_symbols
 
 
-class AccountValidityConfig(Config):
-    section = "accountvalidity"
-
-    def __init__(self, config, synapse_config):
-        if config is None:
-            return
-        super().__init__()
-        self.enabled = config.get("enabled", False)
-        self.renew_by_email_enabled = "renew_at" in config
-
-        # These are set in RegistrationConfig.read_config
-        self.account_renewed_template = None
-        self.account_previously_renewed_template = None
-        self.invalid_token_template = None
-
-        if self.enabled:
-            if "period" in config:
-                self.period = self.parse_duration(config["period"])
-            else:
-                raise ConfigError("'period' is required when using account validity")
-
-            if "renew_at" in config:
-                self.renew_at = self.parse_duration(config["renew_at"])
-
-            if "renew_email_subject" in config:
-                self.renew_email_subject = config["renew_email_subject"]
-            else:
-                self.renew_email_subject = "Renew your %(app)s account"
-
-            self.startup_job_max_delta = self.period * 10.0 / 100.0
-
-        if self.renew_by_email_enabled:
-            if "public_baseurl" not in synapse_config:
-                raise ConfigError("Can't send renewal emails without 'public_baseurl'")
-
-
 class RegistrationConfig(Config):
     section = "registration"
 
@@ -68,34 +32,6 @@ class RegistrationConfig(Config):
             self.enable_registration = not bool(
                 strtobool(str(config["disable_registration"]))
             )
-
-        self.account_validity = AccountValidityConfig(
-            config.get("account_validity") or {}, config
-        )
-
-        # Load account validity templates.
-        # We do this here instead of in AccountValidityConfig as read_templates
-        # relies on state that hasn't been initialised in AccountValidityConfig
-        account_renewed_template_filename = config.get(
-            "account_renewed_html_path", "account_renewed.html"
-        )
-        account_previously_renewed_template_filename = config.get(
-            "account_previously_renewed_html_path", "account_previously_renewed.html"
-        )
-        invalid_token_template_filename = config.get(
-            "invalid_token_html_path", "invalid_token.html"
-        )
-        (
-            self.account_validity.account_renewed_template,
-            self.account_validity.account_previously_renewed_template,
-            self.account_validity.invalid_token_template,
-        ) = self.read_templates(
-            [
-                account_renewed_template_filename,
-                account_previously_renewed_template_filename,
-                invalid_token_template_filename,
-            ]
-        )
 
         self.registrations_require_3pid = config.get("registrations_require_3pid", [])
         self.allowed_local_3pids = config.get("allowed_local_3pids", [])
@@ -260,69 +196,6 @@ class RegistrationConfig(Config):
         # Enable registration for new users.
         #
         #enable_registration: false
-
-        # Optional account validity configuration. This allows for accounts to be denied
-        # any request after a given period.
-        #
-        # Once this feature is enabled, Synapse will look for registered users without an
-        # expiration date at startup and will add one to every account it found using the
-        # current settings at that time.
-        # This means that, if a validity period is set, and Synapse is restarted (it will
-        # then derive an expiration date from the current validity period), and some time
-        # after that the validity period changes and Synapse is restarted, the users'
-        # expiration dates won't be updated unless their account is manually renewed. This
-        # date will be randomly selected within a range [now + period - d ; now + period],
-        # where d is equal to 10%% of the validity period.
-        #
-        account_validity:
-          # The account validity feature is disabled by default. Uncomment the
-          # following line to enable it.
-          #
-          #enabled: true
-
-          # The period after which an account is valid after its registration. When
-          # renewing the account, its validity period will be extended by this amount
-          # of time. This parameter is required when using the account validity
-          # feature.
-          #
-          #period: 6w
-
-          # The amount of time before an account's expiry date at which Synapse will
-          # send an email to the account's email address with a renewal link. By
-          # default, no such emails are sent.
-          #
-          # If you enable this setting, you will also need to fill out the 'email' and
-          # 'public_baseurl' configuration sections.
-          #
-          #renew_at: 1w
-
-          # The subject of the email sent out with the renewal link. '%%(app)s' can be
-          # used as a placeholder for the 'app_name' parameter from the 'email'
-          # section.
-          #
-          # Note that the placeholder must be written '%%(app)s', including the
-          # trailing 's'.
-          #
-          # If this is not set, a default value is used.
-          #
-          #renew_email_subject: "Renew your %%(app)s account"
-
-          # Directory in which Synapse will try to find templates for the HTML files to
-          # serve to the user when trying to renew an account. If not set, default
-          # templates from within the Synapse package will be used.
-          #
-          #template_dir: "res/templates"
-
-          # File within 'template_dir' giving the HTML to be displayed to the user after
-          # they successfully renewed their account. If not set, default text is used.
-          #
-          #account_renewed_html_path: "account_renewed.html"
-
-          # File within 'template_dir' giving the HTML to be displayed when the user
-          # tries to renew an account with an invalid renewal token. If not set,
-          # default text is used.
-          #
-          #invalid_token_html_path: "invalid_token.html"
 
         # Time that a user's session remains valid for, after they log in.
         #

--- a/synapse/handlers/account_validity.py
+++ b/synapse/handlers/account_validity.py
@@ -244,7 +244,7 @@ class AccountValidityHandler:
             renewal_token: Token sent with the renewal request.
         Returns:
             A tuple containing:
-              * A bool representing whether the token is valid.
+              * A bool representing whether the token is valid and unused.
               * A bool representing whether the token is stale.
               * An int representing the user's expiry timestamp as milliseconds since the
                 epoch, or 0 if the token was invalid.

--- a/synapse/handlers/account_validity.py
+++ b/synapse/handlers/account_validity.py
@@ -243,7 +243,6 @@ class AccountValidityHandler:
         try:
             (
                 user_id,
-                email_sent,
                 current_expiration_ts,
                 token_used_ts,
             ) = await self.store.get_user_from_renewal_token(renewal_token)
@@ -261,8 +260,12 @@ class AccountValidityHandler:
 
         logger.debug("Renewing an account for user %s", user_id)
 
-        # Renew the account. Keep the renewal token intact for idempotency in case the
-        # user attempts to renew their account with the same token.
+        # Renew the account. Pass the renewal_token here so that it is not cleared.
+        # We want to keep the token around in case the user attempts to renew their
+        # account with the same token twice (clicking the email link twice).
+        #
+        # In that case, the token will be accepted, but the account's expiration ts
+        # will remain unchanged.
         new_expiration_ts = await self.renew_account_for_user(
             user_id, renewal_token=renewal_token
         )

--- a/synapse/handlers/account_validity.py
+++ b/synapse/handlers/account_validity.py
@@ -254,9 +254,10 @@ class AccountValidityHandler:
         # True if a user is found and email_sent is False, meaning the token has already
         # been used. False otherwise.
         if not email_sent:
-            logger.warning(
-                "User %s attempted to use previously used token to renew account",
+            logger.info(
+                "User '%s' attempted to use previously used token '%s' to renew account",
                 user_id,
+                renewal_token,
             )
             return False, True, current_expiration_ts
 

--- a/synapse/handlers/account_validity.py
+++ b/synapse/handlers/account_validity.py
@@ -262,7 +262,7 @@ class AccountValidityHandler:
 
         logger.debug("Renewing an account for user %s", user_id)
 
-        # Renew the account. Keep the renewal token in tact for idempotency in case the
+        # Renew the account. Keep the renewal token intact for idempotency in case the
         # user attempts to renew their account with the same token.
         new_expiration_ts = await self.renew_account_for_user(
             user_id, renewal_token=renewal_token

--- a/synapse/handlers/account_validity.py
+++ b/synapse/handlers/account_validity.py
@@ -44,6 +44,7 @@ class AccountValidityHandler:
         self._show_users_in_user_directory = self.hs.config.show_users_in_user_directory
         self.profile_handler = self.hs.get_profile_handler()
 
+        self._account_validity_period = None
         if self._account_validity_enabled:
             self._account_validity_period = self.hs.config.account_validity_period
 
@@ -54,21 +55,19 @@ class AccountValidityHandler:
             # Don't do email-specific configuration if renewal by email is disabled.
             self._template_html = self.config.account_validity_template_html
             self._template_text = self.config.account_validity_template_text
-            self._account_validity_renew_email_subject = (
+            account_validity_renew_email_subject = (
                 self.hs.config.account_validity_renew_email_subject
             )
 
             try:
                 app_name = self.hs.config.email_app_name
 
-                self._subject = self._account_validity_renew_email_subject % {
-                    "app": app_name
-                }
+                self._subject = account_validity_renew_email_subject % {"app": app_name}
 
                 self._from_string = self.hs.config.email_notif_from % {"app": app_name}
             except Exception:
                 # If substitution failed, fall back to the bare strings.
-                self._subject = self._account_validity_renew_email_subject
+                self._subject = account_validity_renew_email_subject
                 self._from_string = self.hs.config.email_notif_from
 
             self._raw_from = email.utils.parseaddr(self._from_string)[1]

--- a/synapse/handlers/deactivate_account.py
+++ b/synapse/handlers/deactivate_account.py
@@ -46,7 +46,7 @@ class DeactivateAccountHandler(BaseHandler):
         if hs.config.worker_app is None:
             hs.get_reactor().callWhenRunning(self._start_user_parting)
 
-        self._account_validity_enabled = hs.config.account_validity.enabled
+        self._account_validity_enabled = hs.config.account_validity_enabled
 
     async def deactivate_account(
         self, user_id: str, erase_data: bool, id_server: Optional[str] = None

--- a/synapse/push/pusherpool.py
+++ b/synapse/push/pusherpool.py
@@ -60,7 +60,7 @@ class PusherPool:
         self.store = self.hs.get_datastore()
         self.clock = self.hs.get_clock()
 
-        self._account_validity = hs.config.account_validity
+        self._account_validity_enabled = hs.config.account_validity_enabled
 
         # We shard the handling of push notifications by user ID.
         self._pusher_shard_config = hs.config.push.pusher_shard_config
@@ -205,7 +205,7 @@ class PusherPool:
 
             for u in users_affected:
                 # Don't push if the user account has expired
-                if self._account_validity.enabled:
+                if self._account_validity_enabled:
                     expired = await self.store.is_account_expired(
                         u, self.clock.time_msec()
                     )
@@ -233,7 +233,7 @@ class PusherPool:
 
             for u in users_affected:
                 # Don't push if the user account has expired
-                if self._account_validity.enabled:
+                if self._account_validity_enabled:
                     expired = await self.store.is_account_expired(
                         u, self.clock.time_msec()
                     )

--- a/synapse/res/templates/account_previously_renewed.html
+++ b/synapse/res/templates/account_previously_renewed.html
@@ -1,0 +1,1 @@
+<html><body>Your account is valid until {{ expiration_ts|format_ts("%d-%m-%Y") }}.</body><html>

--- a/synapse/res/templates/account_renewed.html
+++ b/synapse/res/templates/account_renewed.html
@@ -1,1 +1,1 @@
-<html><body>Your account has been successfully renewed until {{ expiration_ts|format_ts("%d-%m-%Y") }}.</body><html>
+<html><body>Your account has been successfully renewed and is valid until {{ expiration_ts|format_ts("%d-%m-%Y") }}.</body><html>

--- a/synapse/res/templates/account_renewed.html
+++ b/synapse/res/templates/account_renewed.html
@@ -1,1 +1,1 @@
-<html><body>Your account has been successfully renewed.</body><html>
+<html><body>Your account has been successfully renewed until {{ expiration_ts|format_ts("%d-%m-%Y") }}.</body><html>

--- a/synapse/rest/client/v2_alpha/account_validity.py
+++ b/synapse/rest/client/v2_alpha/account_validity.py
@@ -38,12 +38,12 @@ class AccountValidityRenewServlet(RestServlet):
         self.account_activity_handler = hs.get_account_validity_handler()
         self.auth = hs.get_auth()
         self.account_renewed_template = (
-            hs.config.account_validity.account_renewed_template
+            hs.config.account_validity_account_renewed_template
         )
         self.account_previously_renewed_template = (
-            hs.config.account_validity.account_previously_renewed_template
+            hs.config.account_validity_account_previously_renewed_template
         )
-        self.invalid_token_template = hs.config.account_validity.invalid_token_template
+        self.invalid_token_template = hs.config.account_validity_invalid_token_template
 
     async def on_GET(self, request):
         if b"token" not in request.args:
@@ -86,10 +86,12 @@ class AccountValiditySendMailServlet(RestServlet):
         self.hs = hs
         self.account_activity_handler = hs.get_account_validity_handler()
         self.auth = hs.get_auth()
-        self.account_validity = self.hs.config.account_validity
+        self.account_validity_renew_by_email_enabled = (
+            self.hs.config.account_validity_renew_by_email_enabled
+        )
 
     async def on_POST(self, request):
-        if not self.account_validity.renew_by_email_enabled:
+        if not self.account_validity_renew_by_email_enabled:
             raise AuthError(
                 403, "Account renewal via email is disabled on this server."
             )

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -248,7 +248,7 @@ class RegistrationWorkerStore(SQLBaseStore):
         ret_dict = await self.db_pool.simple_select_one(
             table="account_validity",
             keyvalues={"renewal_token": renewal_token},
-            retcols=["user_id", "email_sent", "expiration_ts_ms", "token_used_ts_ms"],
+            retcols=["user_id", "expiration_ts_ms", "token_used_ts_ms"],
             desc="get_user_from_renewal_token",
         )
 

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -1011,6 +1011,8 @@ class RegistrationStore(RegistrationBackgroundUpdateStore):
         self._account_validity_enabled = hs.config.account_validity_enabled
         self._ignore_unknown_session_error = hs.config.request_token_inhibit_3pid_errors
 
+        self._account_validity_period = None
+        self._account_validity_startup_job_max_delta = None
         if self._account_validity_enabled:
             self._account_validity_period = hs.config.account_validity_period
             self._account_validity_startup_job_max_delta = (

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -237,6 +237,8 @@ class RegistrationWorkerStore(SQLBaseStore):
                 * The ID of a user to which the token belongs.
                 * Whether an email has been sent to the user with the token, and
                     that they haven't renewed their account with it yet.
+                * An int representing the user's expiry timestamp as milliseconds since the
+                    epoch, or 0 if the token was invalid.
         """
         ret_dict = await self.db_pool.simple_select_one(
             table="account_validity",

--- a/synapse/storage/databases/main/registration.py
+++ b/synapse/storage/databases/main/registration.py
@@ -230,7 +230,7 @@ class RegistrationWorkerStore(SQLBaseStore):
 
     async def get_user_from_renewal_token(
         self, renewal_token: str
-    ) -> Tuple[str, bool, int, Optional[int]]:
+    ) -> Tuple[str, int, Optional[int]]:
         """Get a user ID and renewal status from a renewal token.
 
         Args:
@@ -239,8 +239,6 @@ class RegistrationWorkerStore(SQLBaseStore):
         Returns:
             A tuple of containing the following values:
                 * The ID of a user to which the token belongs.
-                * Whether an email has been sent to the user with the token, and
-                    that they haven't renewed their account with it yet.
                 * An int representing the user's expiry timestamp as milliseconds since the
                     epoch, or 0 if the token was invalid.
                 * An optional int representing the timestamp of when the user renewed their
@@ -256,7 +254,6 @@ class RegistrationWorkerStore(SQLBaseStore):
 
         return (
             ret_dict["user_id"],
-            ret_dict["email_sent"],
             ret_dict["expiration_ts_ms"],
             ret_dict["token_used_ts_ms"],
         )

--- a/synapse/storage/databases/main/schema/delta/58/19account_validity_token_used_ts_ms.sql
+++ b/synapse/storage/databases/main/schema/delta/58/19account_validity_token_used_ts_ms.sql
@@ -1,0 +1,18 @@
+/* Copyright 2020 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- Track when users renew their account using the value of the 'renewal_token' column.
+-- This field should be set to NULL after a fresh token is generated.
+ALTER TABLE account_validity ADD token_used_ts_ms BIGINT;

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -704,7 +704,7 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
 
         # Check that the HTML we're getting is the one we expect on a successful renewal.
         expiration_ts = self.get_success(self.store.get_expiration_ts_for_user(user_id))
-        expected_html = self.hs.config.account_validity.account_renewed_template.render(
+        expected_html = self.hs.config.account_validity_account_renewed_template.render(
             expiration_ts=expiration_ts
         )
         self.assertEqual(
@@ -723,7 +723,7 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
 
         # Check that the HTML we're getting is the one we expect when reusing a
         # token. The account expiration date should not have changed.
-        expected_html = self.hs.config.account_validity.account_previously_renewed_template.render(
+        expected_html = self.hs.config.account_validity_account_previously_renewed_template.render(
             expiration_ts=expiration_ts
         )
         self.assertEqual(
@@ -752,7 +752,7 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
 
         # Check that the HTML we're getting is the one we expect when using an
         # invalid/unknown token.
-        expected_html = self.hs.config.account_validity.invalid_token_template.render()
+        expected_html = self.hs.config.account_validity_invalid_token_template.render()
         self.assertEqual(
             channel.result["body"], expected_html.encode("utf8"), channel.result
         )
@@ -863,7 +863,7 @@ class AccountValidityBackgroundJobTestCase(unittest.HomeserverTestCase):
         config["account_validity"] = {"enabled": False}
 
         self.hs = self.setup_test_homeserver(config=config)
-        self.hs.config.account_validity.period = self.validity_period
+        self.hs.config.account_validity_period = self.validity_period
 
         self.store = self.hs.get_datastore()
 
@@ -877,7 +877,7 @@ class AccountValidityBackgroundJobTestCase(unittest.HomeserverTestCase):
         """
         user_id = self.register_user("kermit_delta", "user")
 
-        self.hs.config.account_validity.startup_job_max_delta = self.max_delta
+        self.hs.config.account_validity_startup_job_max_delta = self.max_delta
 
         now_ms = self.hs.clock.time_msec()
         self.get_success(self.store._set_expiration_date_when_missing())

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -699,11 +699,8 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
         self.assertEquals(channel.result["code"], b"200", channel.result)
 
         # Check that we're getting HTML back.
-        content_type = None
-        for header in channel.result.get("headers", []):
-            if header[0] == b"Content-Type":
-                content_type = header[1]
-        self.assertEqual(content_type, b"text/html; charset=utf-8", channel.result)
+        content_type = channel.headers.getRawHeaders(b"Content-Type")
+        self.assertEqual(content_type, [b"text/html; charset=utf-8"], channel.result)
 
         # Check that the HTML we're getting is the one we expect on a successful renewal.
         expiration_ts = self.get_success(self.store.get_expiration_ts_for_user(user_id))
@@ -721,11 +718,8 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
         self.assertEquals(channel.result["code"], b"200", channel.result)
 
         # Check that we're getting HTML back.
-        content_type = None
-        for header in channel.result.get("headers", []):
-            if header[0] == b"Content-Type":
-                content_type = header[1]
-        self.assertEqual(content_type, b"text/html; charset=utf-8", channel.result)
+        content_type = channel.headers.getRawHeaders(b"Content-Type")
+        self.assertEqual(content_type, [b"text/html; charset=utf-8"], channel.result)
 
         # Check that the HTML we're getting is the one we expect when reusing a
         # token. The account expiration date should not have changed.
@@ -753,11 +747,8 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
         self.assertEquals(channel.result["code"], b"404", channel.result)
 
         # Check that we're getting HTML back.
-        content_type = None
-        for header in channel.result.get("headers", []):
-            if header[0] == b"Content-Type":
-                content_type = header[1]
-        self.assertEqual(content_type, b"text/html; charset=utf-8", channel.result)
+        content_type = channel.headers.getRawHeaders(b"Content-Type")
+        self.assertEqual(content_type, [b"text/html; charset=utf-8"], channel.result)
 
         # Check that the HTML we're getting is the one we expect when using an
         # invalid/unknown token.

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -863,7 +863,7 @@ class AccountValidityBackgroundJobTestCase(unittest.HomeserverTestCase):
         config["account_validity"] = {"enabled": False}
 
         self.hs = self.setup_test_homeserver(config=config)
-        self.hs.config.account_validity_period = self.validity_period
+        self.hs.get_datastore()._account_validity_period = self.validity_period
 
         self.store = self.hs.get_datastore()
 
@@ -877,7 +877,7 @@ class AccountValidityBackgroundJobTestCase(unittest.HomeserverTestCase):
         """
         user_id = self.register_user("kermit_delta", "user")
 
-        self.hs.config.account_validity_startup_job_max_delta = self.max_delta
+        self.hs.get_datastore()._account_validity_startup_job_max_delta = self.max_delta
 
         now_ms = self.hs.clock.time_msec()
         self.get_success(self.store._set_expiration_date_when_missing())

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -863,7 +863,12 @@ class AccountValidityBackgroundJobTestCase(unittest.HomeserverTestCase):
         config["account_validity"] = {"enabled": False}
 
         self.hs = self.setup_test_homeserver(config=config)
+
+        # We need to set these directly, instead of in the homeserver config dict above.
+        # This is due to account validity-related config options not being read by
+        # Synapse when account_validity.enabled is False.
         self.hs.get_datastore()._account_validity_period = self.validity_period
+        self.hs.get_datastore()._account_validity_startup_job_max_delta = self.max_delta
 
         self.store = self.hs.get_datastore()
 
@@ -876,8 +881,6 @@ class AccountValidityBackgroundJobTestCase(unittest.HomeserverTestCase):
         allowed range.
         """
         user_id = self.register_user("kermit_delta", "user")
-
-        self.hs.get_datastore()._account_validity_startup_job_max_delta = self.max_delta
 
         now_ms = self.hs.clock.time_msec()
         self.get_success(self.store._set_expiration_date_when_missing())

--- a/tests/rest/client/v2_alpha/test_register.py
+++ b/tests/rest/client/v2_alpha/test_register.py
@@ -706,7 +706,10 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
         self.assertEqual(content_type, b"text/html; charset=utf-8", channel.result)
 
         # Check that the HTML we're getting is the one we expect on a successful renewal.
-        expected_html = self.hs.config.account_validity.account_renewed_html_content
+        expiration_ts = self.get_success(self.store.get_expiration_ts_for_user(user_id))
+        expected_html = self.hs.config.account_validity.account_renewed_template.render(
+            expiration_ts=expiration_ts
+        )
         self.assertEqual(
             channel.result["body"], expected_html.encode("utf8"), channel.result
         )
@@ -736,7 +739,7 @@ class AccountValidityRenewalByEmailTestCase(unittest.HomeserverTestCase):
 
         # Check that the HTML we're getting is the one we expect when using an
         # invalid/unknown token.
-        expected_html = self.hs.config.account_validity.invalid_token_html_content
+        expected_html = self.hs.config.account_validity.invalid_token_template.render()
         self.assertEqual(
             channel.result["body"], expected_html.encode("utf8"), channel.result
         )


### PR DESCRIPTION
This PR makes some modifications to the account renewal endpoint to enable idempotency. For context, when the [account validity](https://github.com/matrix-org/synapse-dinsic/blob/854764073c984da8d7f5daf713a550b2c9691f11/docs/sample_config.yaml#L1195-L1208) feature is in use, users are sent an email with a renewal link a little while before their account expires.

Users may end up clicking this link twice accidentally, or their spam software will click it for them before they have a chance to do so manually. In each case, every click after the first would return an Invalid Token error page, as we delete renewal tokens once used.

This PR changes things up a bit. We no longer delete the token upon use. However, we also ensure that tokens cannot be re-used by ~~(ab)using the `email_sent` boolean. This boolean is set to True when an email with the token is sent out, and set to False when the account is renewed using that token. With this, and with the token still intact,~~ adding a new `token_used_ts_ms` column to the `account_validity` table. With this, we can check if the token is valid, yet has already been used. In this case, return a new template which simply informs the user of when their account will expire, but not that it was just renewed.

Part of this PR was also adding information about when a user's account would expire in the actual renewal template. Mostly for nicer UX purposes. Doing so meant converting the account validity config code to using the new `read_templates` function, which simplifies it massively!

Reviewable commit-by-commit.