### PR TITLE
Fix Python Old-Deps CI step

### DIFF
--- a/.buildkite/scripts/test_old_deps.sh
+++ b/.buildkite/scripts/test_old_deps.sh
@@ -10,4 +10,7 @@ apt-get install -y python3.5 python3.5-dev python3-pip libxml2-dev libxslt-dev x
 
 export LANG="C.UTF-8"
 
+# Prevent virtualenv from auto-updating pip to an incompatible version
+export VIRTUALENV_NO_DOWNLOAD=1
+
 exec tox -e py35-old,combine

--- a/changelog.d/9146.misc
+++ b/changelog.d/9146.misc
@@ -1,0 +1,1 @@
+Fix the Python 3.5 + old dependencies build in CI.

--- a/changelog.d/9217.misc
+++ b/changelog.d/9217.misc
@@ -1,0 +1,1 @@
+Fix the Python 3.5 old dependencies build.

--- a/tox.ini
+++ b/tox.ini
@@ -17,11 +17,13 @@ deps =
     # installed on that).
     #
     # anyway, make sure that we have a recent enough setuptools.
-    setuptools>=18.5
+    setuptools>=18.5 ; python_version >= '3.6'
+    setuptools>=18.5,<51.0.0 ; python_version < '3.6'
 
     # we also need a semi-recent version of pip, because old ones fail to
     # install the "enum34" dependency of cryptography.
-    pip>=10
+    pip>=10 ; python_version >= '3.6'
+    pip>=10,<21.0 ; python_version < '3.6'
 
 setenv =
     PYTHONDONTWRITEBYTECODE = no_byte_code
@@ -75,15 +77,10 @@ usedevelop=true
 [testenv:py35-old]
 skip_install=True
 deps =
-    # Ensure a version of setuptools that supports Python 3.5 is installed.
-    setuptools < 51.0.0
-
     # Old automat version for Twisted
     Automat == 0.3.0
-
     lxml
-    coverage
-    coverage-enable-subprocess
+    {[base]deps}
 
 commands =
     /usr/bin/find "{toxinidir}" -name '*.pyc' -delete
@@ -137,6 +134,8 @@ commands = {toxinidir}/scripts-dev/generate_sample_config --check
 skip_install = True
 deps =
     coverage
+    pip>=10 ; python_version >= '3.6'
+    pip>=10,<21.0 ; python_version < '3.6'
 commands=
     coverage combine
     coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,9 @@ usedevelop=true
 [testenv:py35-old]
 skip_install=True
 deps =
+    # Ensure a version of setuptools that supports Python 3.5 is installed.
+    setuptools < 51.0.0
+
     # Old automat version for Twisted
     Automat == 0.3.0
 


### PR DESCRIPTION
This PR simply pulls in https://github.com/matrix-org/synapse/pull/9146 and https://github.com/matrix-org/synapse/pull/9217 which fixed the CI after some libraries dropped Python 3.5 support.