### PR TITLE
Add complement running monolith synapse to buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -492,3 +492,39 @@ steps:
 #
 #  - label: Trigger webhook
 #    command: "curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d \"payload[build_num]=$BUILDKITE_BUILD_NUMBER&payload[status]=done\""
+
+  ################################################################################
+  #
+  # Complement Test Suite
+  #
+  ################################################################################
+
+  - command:
+      # Build a docker image from the checked out Synapse source
+      - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
+      # We use the complement:latest image to provide Complement's dependencies, but want
+      # to actually run against the latest version of Complement, so download it here.
+      - "wget https://github.com/matrix-org/complement/archive/master.tar.gz"
+      - "tar -xzf master.tar.gz"
+      # Build a second docker image on top of the above image. This one sets up Synapse with a generated config file,
+      # signing and SSL keys so Synapse can run and federate
+      - "docker build -t complement-synapse -f complement-master/dockerfiles/Synapse.Dockerfile complement-master/dockerfiles"
+      # Finally, compile and run the tests.
+      - "cd complement-master"
+      - "COMPLEMENT_BASE_IMAGE=complement-synapse:latest go test -v -tags synapse_blacklist ./tests"
+    label: "\U0001F9EA Complement"
+    agents:
+      queue: "medium"
+    plugins:
+      - docker#v3.7.0:
+          # The dockerfile for this image is at https://github.com/matrix-org/complement/blob/master/dockerfiles/ComplementCIBuildkite.Dockerfile.
+          image: "matrixdotorg/complement:latest"
+          mount-buildkite-agent: false
+          # Complement needs to know if it is running under CI
+          environment:
+           - "CI=true"
+          publish: [ "8448:8448" ]
+          # Complement uses Docker so pass through the docker socket. This means Complement shares
+          # the hosts Docker.
+          volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
This PR adds Complement running Synapse in monolith mode (no workers) to DINUM's CI pipeline.

A future PR will add Synapse running in worker mode.