### PR TITLE
Send a ver query parameter for make_knock

### DIFF
--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -550,7 +550,8 @@ class FederationMakeKnockServlet(BaseFederationServlet):
     PREFIX = FEDERATION_UNSTABLE_PREFIX + "/xyz.amorgan.knock"
 
     async def on_GET(self, origin, content, query, room_id, user_id):
-        supported_versions = query.get(b"ver")
+        versions = query.get(b"ver")
+        supported_versions = [v.decode("utf-8") for v in versions]
         content = await self.handler.on_make_knock_request(
             origin, room_id, user_id, supported_versions=supported_versions
         )

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -550,7 +550,10 @@ class FederationMakeKnockServlet(BaseFederationServlet):
     PREFIX = FEDERATION_UNSTABLE_PREFIX + "/xyz.amorgan.knock"
 
     async def on_GET(self, origin, content, query, room_id, user_id):
-        content = await self.handler.on_make_knock_request(origin, room_id, user_id)
+        supported_versions = query.get(b"ver")
+        content = await self.handler.on_make_knock_request(
+            origin, room_id, user_id, supported_versions=supported_versions
+        )
         return 200, content
 
 

--- a/synapse/federation/transport/server.py
+++ b/synapse/federation/transport/server.py
@@ -15,7 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import functools
 import logging
 import re
@@ -36,6 +35,7 @@ from synapse.http.servlet import (
     parse_boolean_from_args,
     parse_integer_from_args,
     parse_json_object_from_request,
+    parse_list_from_args,
     parse_string_from_args,
 )
 from synapse.logging.context import run_in_background
@@ -550,8 +550,12 @@ class FederationMakeKnockServlet(BaseFederationServlet):
     PREFIX = FEDERATION_UNSTABLE_PREFIX + "/xyz.amorgan.knock"
 
     async def on_GET(self, origin, content, query, room_id, user_id):
-        versions = query.get(b"ver")
-        supported_versions = [v.decode("utf-8") for v in versions]
+        try:
+            # Retrieve the room versions the remote homeserver claims to support
+            supported_versions = parse_list_from_args(query, "ver", encoding="utf-8")
+        except KeyError:
+            raise SynapseError(400, "Missing required query parameter 'ver'")
+
         content = await self.handler.on_make_knock_request(
             origin, room_id, user_id, supported_versions=supported_versions
         )

--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1470,10 +1470,14 @@ class FederationHandler(BaseHandler):
         """
         logger.debug("Knocking on room %s on behalf of user %s", room_id, knockee)
 
+        # Inform the remote server of the room versions we support
+        supported_room_versions = list(KNOWN_ROOM_VERSIONS.keys())
+
         # Ask the remote server to create a valid knock event for us. Once received,
         # we sign the event
+        params = {"ver": supported_room_versions}  # type: Dict[str, Iterable[str]]
         origin, event, event_format_version = await self._make_and_verify_event(
-            target_hosts, room_id, knockee, Membership.KNOCK, content,
+            target_hosts, room_id, knockee, Membership.KNOCK, content, params=params
         )
 
         # Record the room ID and its version so that we have a record of the room
@@ -1875,6 +1879,7 @@ class FederationHandler(BaseHandler):
             raise SynapseError(403, "User not from origin", Codes.FORBIDDEN)
 
         room_version = await self.store.get_room_version_id(room_id)
+
         builder = self.event_builder_factory.new(
             room_version,
             {

--- a/tests/federation/transport/test_knocking.py
+++ b/tests/federation/transport/test_knocking.py
@@ -229,8 +229,15 @@ class FederationKnockingTestCase(
 
         _, channel = self.make_request(
             "GET",
-            "/_matrix/federation/unstable/%s/make_knock/%s/%s"
-            % (KNOCK_UNSTABLE_IDENTIFIER, room_id, fake_knocking_user_id),
+            "/_matrix/federation/unstable/%s/make_knock/%s/%s?ver=%s"
+            % (
+                KNOCK_UNSTABLE_IDENTIFIER,
+                room_id,
+                fake_knocking_user_id,
+                # Inform the remote that we support the room version of the room we're
+                # knocking on
+                RoomVersions.MSC2403_DEV.identifier,
+            ),
         )
         self.assertEquals(200, channel.code, channel.result)
 


### PR DESCRIPTION
This informs the remote server of the room versions we support. If the room we're trying to
knock on has a version that is not one of our supported room versions, the remote server
will return an unsupported room version error.

Noticed in https://github.com/matrix-org/matrix-doc/pull/2403#discussion_r577042144

Ported from https://github.com/matrix-org/synapse/pull/6739