### PR TITLE
Allow knock->knock transitions

### DIFF
--- a/synapse/event_auth.py
+++ b/synapse/event_auth.py
@@ -355,8 +355,6 @@ def _is_membership_change_allowed(
             raise AuthError(403, "You cannot knock for other users")
         elif target_in_room:
             raise AuthError(403, "You cannot knock on a room you are already in")
-        elif caller_knocked:
-            raise AuthError(403, "You already have a pending knock for this room")
         elif caller_invited:
             raise AuthError(403, "You are already invited to this room")
         elif target_banned:


### PR DESCRIPTION
Small change to the event auth rules that allows transitioning from knock->knock (in case you want to update your knock reason, or change profile information etc).

Coincides with the same commit in [the mainline PR](https://github.com/matrix-org/synapse/pull/6739) and [this update on MSC2403](https://github.com/matrix-org/matrix-doc/pull/2403/commits/49a72862a93d814219968cff814ff63926181645).

~~Waiting on https://github.com/matrix-org/complement/pull/76 before CI will pass.~~ Merged.