### PR TITLE
Change knocking room version to v7

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -504,7 +504,7 @@ steps:
       - "docker build -t matrixdotorg/synapse:latest -f docker/Dockerfile ."
       # We use the complement:latest image to provide Complement's dependencies, but want
       # to actually run against the latest version of Complement, so download it here.
-      - "wget https://github.com/matrix-org/complement/archive/master.tar.gz"
+      - "wget https://github.com/matrix-org/complement/archive/anoa/knock_room_v7.tar.gz"
       - "tar -xzf master.tar.gz"
       # Build a second docker image on top of the above image. This one sets up Synapse with a generated config file,
       # signing and SSL keys so Synapse can run and federate

--- a/synapse/api/room_versions.py
+++ b/synapse/api/room_versions.py
@@ -147,6 +147,18 @@ class RoomVersions:
         msc2176_redaction_rules=False,
         allow_knocking=False,
     )
+    V7 = RoomVersion(
+        "7",
+        RoomDisposition.UNSTABLE,
+        EventFormatVersions.V3,
+        StateResolutionVersions.V2,
+        enforce_key_validity=True,
+        special_case_aliases_auth=False,
+        strict_canonicaljson=True,
+        limit_notifications_power_levels=True,
+        msc2176_redaction_rules=False,
+        allow_knocking=True,
+    )
     MSC2176 = RoomVersion(
         "org.matrix.msc2176",
         RoomDisposition.UNSTABLE,
@@ -159,18 +171,6 @@ class RoomVersions:
         msc2176_redaction_rules=True,
         allow_knocking=False,
     )
-    MSC2403_DEV = RoomVersion(
-        "xyz.amorgan.knock",
-        RoomDisposition.UNSTABLE,
-        EventFormatVersions.V3,
-        StateResolutionVersions.V2,
-        enforce_key_validity=True,
-        special_case_aliases_auth=False,
-        strict_canonicaljson=True,
-        limit_notifications_power_levels=True,
-        msc2176_redaction_rules=False,
-        allow_knocking=True,
-    )
 
 
 KNOWN_ROOM_VERSIONS = {
@@ -182,5 +182,6 @@ KNOWN_ROOM_VERSIONS = {
         RoomVersions.V4,
         RoomVersions.V5,
         RoomVersions.V6,
+        RoomVersions.V7,
     )
 }  # type: Dict[str, RoomVersion]

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -30,6 +30,4 @@ class ExperimentalConfig(Config):
         self.msc2403_enabled = experimental.get("msc2403_enabled", False)  # type: bool
         if self.msc2403_enabled:
             # Enable the MSC2403 unstable room version
-            KNOWN_ROOM_VERSIONS.update(
-                {RoomVersions.MSC2403_DEV.identifier: RoomVersions.MSC2403_DEV}
-            )
+            KNOWN_ROOM_VERSIONS.update({RoomVersions.V7.identifier: RoomVersions.V7})

--- a/tests/federation/transport/test_knocking.py
+++ b/tests/federation/transport/test_knocking.py
@@ -61,7 +61,7 @@ class KnockingStrippedStateEventHelperMixin(TestCase):
         self.get_success(
             event_injection.inject_event(
                 hs,
-                room_version=RoomVersions.MSC2403_DEV.identifier,
+                room_version=RoomVersions.V7.identifier,
                 room_id=room_id,
                 sender=sender,
                 type="com.example.secret",
@@ -121,7 +121,7 @@ class KnockingStrippedStateEventHelperMixin(TestCase):
             self.get_success(
                 event_injection.inject_event(
                     hs,
-                    room_version=RoomVersions.MSC2403_DEV.identifier,
+                    room_version=RoomVersions.V7.identifier,
                     room_id=room_id,
                     sender=sender,
                     type=event_type,
@@ -218,7 +218,7 @@ class FederationKnockingTestCase(
         room_id = self.helper.create_room_as(
             "u1",
             is_public=False,
-            room_version=RoomVersions.MSC2403_DEV.identifier,
+            room_version=RoomVersions.V7.identifier,
             tok=user_token,
         )
 
@@ -236,7 +236,7 @@ class FederationKnockingTestCase(
                 fake_knocking_user_id,
                 # Inform the remote that we support the room version of the room we're
                 # knocking on
-                RoomVersions.MSC2403_DEV.identifier,
+                RoomVersions.V7.identifier,
             ),
         )
         self.assertEquals(200, channel.code, channel.result)
@@ -261,7 +261,7 @@ class FederationKnockingTestCase(
             self.clock,
             self.hs.hostname,
             self.hs.signing_key,
-            room_version=RoomVersions.MSC2403_DEV,
+            room_version=RoomVersions.V7,
             event_dict=knock_event,
         )
 

--- a/tests/rest/client/v2_alpha/test_sync.py
+++ b/tests/rest/client/v2_alpha/test_sync.py
@@ -17,6 +17,7 @@ import json
 
 import synapse.rest.admin
 from synapse.api.constants import EventContentFields, EventTypes, RelationTypes
+from synapse.api.room_versions import RoomVersions
 from synapse.rest.client.v1 import login, room
 from synapse.rest.client.v2_alpha import knock, read_marker, sync
 
@@ -342,7 +343,7 @@ class SyncKnockTestCase(
         self.room_id = self.helper.create_room_as(
             self.user_id,
             is_public=False,
-            room_version="xyz.amorgan.knock",
+            room_version=RoomVersions.V7.identifier,
             tok=self.tok,
         )
 


### PR DESCRIPTION
Room version 7 has been defined as what MSC2403 follows, which has been implemented in `synapse-dinsic`. Thus we're switching the room version from the unstable identifier to officially be v7: https://github.com/matrix-org/matrix-doc/pull/2998