### PR TITLE
Temporary fix to mypy CI to address newer Twisted versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -157,6 +157,9 @@ commands=
 [testenv:mypy]
 deps =
     {[base]deps}
+    # Type hints are broken with Twisted > 20.3.0, see https://github.com/matrix-org/synapse/issues/9513
+    # TODO: Remove after merging in the fixes from mainline
+    twisted==20.3.0
 extras = all,mypy
 commands = mypy
 


### PR DESCRIPTION
First phase of addressing #89 

This PR caps the version of Twisted to `20.3.0` in the `mypy` tests, as Twisted >v20.3.0 exposed some inconsistencies in our type hints (and bugs in some dependencies). Context is here: https://github.com/matrix-org/synapse/issues/9513

We'll remove this cap again once we pull in all the fixes from mainline.