### PR TITLE
Remove extraneous print

### DIFF
--- a/synapse/rest/client/v2_alpha/register.py
+++ b/synapse/rest/client/v2_alpha/register.py
@@ -500,7 +500,6 @@ class RegisterRestServlet(RestServlet):
         # Check if the user-interactive authentication flows are complete, if
         # not this will raise a user-interactive auth error.
         try:
-            print("Trying")
             auth_result, params, session_id = await self.auth_handler.check_ui_auth(
                 self._registration_flows,
                 request,


### PR DESCRIPTION
Occasionally you might see "Trying" appear in stdout when running `synapse-dinsic`.

That was due to an extraneous log line that accidentally got merged in.

This PR cleans it up.