### PR TITLE
Stabilise all knock-related unstable identifiers that would be in state

### DIFF
--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -34,7 +34,7 @@ class Membership:
 
     INVITE = "invite"
     JOIN = "join"
-    KNOCK = "xyz.amorgan.knock"
+    KNOCK = "knock"
     LEAVE = "leave"
     BAN = "ban"
     LIST = (INVITE, JOIN, KNOCK, LEAVE, BAN)
@@ -50,7 +50,7 @@ class PresenceState:
 
 class JoinRules:
     PUBLIC = "public"
-    KNOCK = "xyz.amorgan.knock"
+    KNOCK = "knock"
     INVITE = "invite"
     PRIVATE = "private"
 

--- a/tests/rest/client/v2_alpha/test_sync.py
+++ b/tests/rest/client/v2_alpha/test_sync.py
@@ -16,7 +16,12 @@
 import json
 
 import synapse.rest.admin
-from synapse.api.constants import EventContentFields, EventTypes, RelationTypes
+from synapse.api.constants import (
+    EventContentFields,
+    EventTypes,
+    Membership,
+    RelationTypes,
+)
 from synapse.api.room_versions import RoomVersions
 from synapse.rest.client.v1 import login, room
 from synapse.rest.client.v2_alpha import knock, read_marker, sync
@@ -379,7 +384,7 @@ class SyncKnockTestCase(
 
         # We expect to see the knock event in the stripped room state later
         self.expected_room_state[EventTypes.Member] = {
-            "content": {"membership": "xyz.amorgan.knock", "displayname": "knocker"},
+            "content": {"membership": Membership.KNOCK, "displayname": "knocker"},
             "state_key": "@knocker:test",
         }
 
@@ -390,7 +395,7 @@ class SyncKnockTestCase(
         self.assertEqual(channel.code, 200, channel.json_body)
 
         # Extract the stripped room state events from /sync
-        knock_entry = channel.json_body["rooms"]["xyz.amorgan.knock"]
+        knock_entry = channel.json_body["rooms"][Membership.KNOCK]
         room_state_events = knock_entry[self.room_id]["knock_state"]["events"]
 
         # Validate that the knock membership event came last


### PR DESCRIPTION
To ensure compatibility between DINUM and mainline Synapse instances after mainline Synapse drops unstable `xyz.amorgan.knock` room versions, we need to ensure that DINUM won't try to serve any state events which contain an unstable knock identifier. For instance, if DINUM was creating membership events with type `xyz.amorgan.knock`, a future mainline Synapse would have no idea what to do with that, and the room would split-brain.

To ensure compatibility with future mainline versions of Synapse, we remove all unstable knock identifiers from DINUM's Synapse. We do, however, leave the unstable identifiers for CS and Federation endpoints, as those can be updated without worrying about historical room state (and the less deviations from mainline Synapse we make, the better).

Thus, Tchap should be expected to still use e.g `/_matrix/client/unstable/xyz.amorgan.xyz/knock` to send knocks into a room, but should expect to receive membership events and join_rules of `"knock"`, instead of `"xyz.amorgan.knock"`.