### PR TITLE
Switch back to using Sytest dinsic branch

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -296,11 +296,8 @@ steps:
   # This is configured by setting `MULTI_POSTGRES=1` in the environment.
   #
   # We mostly care about testing each topology.
-  # To vary the Python and Postgres versions, we use Docker images which are based
-  # on an assortment of Linux distributions.
-  #   - "bionic" (Ubuntu 18.04) has Python 3.6 and Postgres 10
-  #   - "buster" (Debian 10) has Python 3.7 and Postgres 11
-  #   - "testing" (Debian 11) (currently) has Python 3.9 and Postgres 13
+  # For DINSIC specifically, we currently test across one Linux distribution,
+  # Debian buster (10), which has Python 3.7 and Postgres 11
   #
   # TODO: this leaves us without sytests for Postgres 9.6. How much do we care
   #    about that?

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -318,31 +318,7 @@ steps:
   #
   ################################################################################
 
-  - label: "SyTest Monolith :sqlite::ubuntu: 18.04"
-    agents:
-      queue: "medium"
-    command:
-      - "bash .buildkite/merge_base_branch.sh"
-      - "bash /bootstrap.sh synapse"
-    plugins:
-      - docker#v3.7.0:
-          image: "matrixdotorg/sytest-synapse:bionic"
-          propagate-environment: true
-          always-pull: true
-          workdir: "/src"
-          entrypoint: "/bin/sh"
-          init: false
-          shell: ["-x", "-c"]
-          mount-buildkite-agent: false
-          volumes: ["./logs:/logs"]
-      - artifacts#v1.3.0:
-          upload: [ "logs/**/*.log", "logs/**/*.log.*", "logs/results.tap" ]
-      - matrix-org/annotate:
-          path: "logs/annotate.md"
-          style: "error"
-    retry: *retry_setup
-
-  - label: "SyTest Monolith :postgres::ubuntu: 18.04"
+  - label: "SyTest Monolith :postgres::debian: 10"
     agents:
       queue: "medium"
     env:
@@ -352,63 +328,7 @@ steps:
       - "bash /bootstrap.sh synapse"
     plugins:
       - docker#v3.7.0:
-          image: "matrixdotorg/sytest-synapse:bionic"
-          propagate-environment: true
-          always-pull: true
-          workdir: "/src"
-          entrypoint: "/bin/sh"
-          init: false
-          shell: ["-x", "-c"]
-          mount-buildkite-agent: false
-          volumes: ["./logs:/logs"]
-      - artifacts#v1.3.0:
-          upload: [ "logs/**/*.log", "logs/**/*.log.*", "logs/results.tap" ]
-      - matrix-org/annotate:
-          path: "logs/annotate.md"
-          style: "error"
-    retry: *retry_setup
-
-  - label: "SyTest Monolith :postgres::debian: testing"
-    agents:
-      queue: "medium"
-    env:
-      POSTGRES: "1"
-    command:
-      - "bash .buildkite/merge_base_branch.sh"
-      - "bash /bootstrap.sh synapse"
-    plugins:
-      - docker#v3.7.0:
-          image: "matrixdotorg/sytest-synapse:testing"
-          propagate-environment: true
-          always-pull: true
-          workdir: "/src"
-          entrypoint: "/bin/sh"
-          init: false
-          shell: ["-x", "-c"]
-          mount-buildkite-agent: false
-          volumes: ["./logs:/logs"]
-      - artifacts#v1.3.0:
-          upload: [ "logs/**/*.log", "logs/**/*.log.*", "logs/results.tap" ]
-      - matrix-org/annotate:
-          path: "logs/annotate.md"
-          style: "error"
-    retry: *retry_setup
-
-  - label: "SyTest Workers :postgres::ubuntu: 18.04"
-    agents:
-      queue: "xlarge"
-    env:
-      MULTI_POSTGRES: "1"  # Test with split out databases
-      POSTGRES: "1"
-      WORKERS: "1"
-      BLACKLIST: "synapse-blacklist-with-workers"
-    command:
-      - "bash .buildkite/merge_base_branch.sh"
-      - "bash -c 'cat /src/sytest-blacklist /src/.buildkite/worker-blacklist > /src/synapse-blacklist-with-workers'"
-      - "bash /bootstrap.sh synapse"
-    plugins:
-      - docker#v3.7.0:
-          image: "matrixdotorg/sytest-synapse:bionic"
+          image: "matrixdotorg/sytest-synapse:dinsic"
           propagate-environment: true
           always-pull: true
           workdir: "/src"
@@ -438,7 +358,7 @@ steps:
       - "bash /bootstrap.sh synapse"
     plugins:
       - docker#v3.7.0:
-          image: "matrixdotorg/sytest-synapse:buster"
+          image: "matrixdotorg/sytest-synapse:dinsic"
           propagate-environment: true
           always-pull: true
           workdir: "/src"
@@ -469,7 +389,7 @@ steps:
       - "bash /bootstrap.sh synapse"
     plugins:
       - docker#v3.7.0:
-          image: "matrixdotorg/sytest-synapse:buster"
+          image: "matrixdotorg/sytest-synapse:dinsic"
           propagate-environment: true
           always-pull: true
           workdir: "/src"


### PR DESCRIPTION
As part of the 1.31.0 mainline merge (#97), we updated the buildkite pipeline to more closely match mainline. Unfortunately we accidentally also updated the sytest portion verbatim, which meant we were now running the `matrixdotorg/sytest-synapse:buster/testing/etc.` images against synapse-dinsic, when really we want `matrixdotorg/sytest-synapse:dinsic`.

Additionally, and perhaps more importantly, [a commit](https://github.com/matrix-org/sytest/commit/a324f6bdce850eee7dae403539718f0e5212b4d3) that landed on Sytest develop which reverted some dinsic-specific changes was accidentally merged into `dinsic`.

Both of these broke the CI as dinsic started to fall behind mainline again.

This PR specifically returns us back to the dinsic tag of matrixdotorg/sytest-synapse, as well as removes some Linux distro variations which we aren't using for dinsic. While [this commit](https://github.com/matrix-org/sytest/commit/4f03e7b4cc98d99fef438e5c4720fa39d8d2b77d) specifically fixes the Sytest portion.

`matrixdotorg/sytest:dinsic` and `matrixdotorg/sytest-synapse:dinsic` each were updated and built with Debian buster (10) for this PR: https://hub.docker.com/r/matrixdotorg/sytest-synapse/tags