### PR TITLE
Rework room freeze and implement unfreezing the room

### DIFF
--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1414,8 +1414,8 @@ class EventCreationHandler:
         for k, v in original_event.internal_metadata.get_dict().items():
             setattr(builder.internal_metadata, k, v)
 
-        # the event type hasn't changed, so there's no point in re-calculating the
-        # auth events.
+        # modules can send new state events, so we re-calculate the auth events just in
+        # case.
         prev_event_ids = await self.store.get_prev_events_for_room(builder.room_id)
 
         event = await builder.build(

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1416,9 +1416,11 @@ class EventCreationHandler:
 
         # the event type hasn't changed, so there's no point in re-calculating the
         # auth events.
+        prev_event_ids = await self.store.get_prev_events_for_room(builder.room_id)
+
         event = await builder.build(
-            prev_event_ids=original_event.prev_event_ids(),
-            auth_event_ids=original_event.auth_event_ids(),
+            prev_event_ids=prev_event_ids,
+            auth_event_ids=None,
         )
 
         # we rebuild the event context, to be on the safe side. If nothing else,

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -43,7 +43,7 @@ class ModuleApi:
     can register new users etc if necessary.
     """
 
-    def __init__(self, hs, auth_handler):
+    def __init__(self, hs: "HomeServer", auth_handler):
         self._hs = hs
 
         self._store = hs.get_datastore()

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -334,7 +334,7 @@ class RoomAccessRules(object):
                 State events in the room the event originated from.
 
         Returns:
-            True if the event can be allowed, False otherwise, or a dictionary if the
+            True if the event should be allowed, False if it should be rejected, or a dictionary if the
             event needs to be rebuilt (containing the event's new content).
         """
         if event.type == FROZEN_STATE_TYPE:

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -473,6 +473,17 @@ class RoomAccessRules(object):
         ):
             return False
 
+        current_frozen_state = (
+            state_events.get((FROZEN_STATE_TYPE, ""))
+        )  # type: EventBase
+
+        if (
+            current_frozen_state is not None
+            and current_frozen_state.content.get("frozen") == frozen
+        ):
+            # This is a noop, accept the new event but don't do anything more.
+            return True
+
         # If the event was received over federation, we want to accept it but not to
         # change the power levels.
         if not self._is_local_user(event.sender):

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -501,9 +501,8 @@ class RoomAccessRules(object):
         if not frozen:
             # We're unfreezing the room: enforce the right value for the power levels so
             # the room isn't in a weird/broken state afterwards.
-            users = power_levels_content.get("users", {})
+            users = power_levels_content.setdefault("users", {})
             users[event.sender] = 100
-            power_levels_content["users"] = users
             power_levels_content["users_default"] = 0
         else:
             # Send a new power levels event with a similar content to the previous one
@@ -624,7 +623,7 @@ class RoomAccessRules(object):
             ):
                 await self._freeze_room_if_last_admin_is_leaving(event, state_events)
                 if ret:
-                    # Return an event dict to force Synapse into rebuilding th event.
+                    # Return an event dict to force Synapse into rebuilding the event.
                     return event.get_dict()
 
         return ret
@@ -687,8 +686,6 @@ class RoomAccessRules(object):
                 "state_key": "",
             }
         )
-
-        return
 
     def _on_membership_or_invite_restricted(self, event: EventBase) -> bool:
         """Implements the checks and behaviour specified for the "restricted" rule.

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -458,7 +458,9 @@ class RoomAccessRules(object):
         return False
 
     async def _on_frozen_state_change(
-        self, event: EventBase, state_events: StateMap[EventBase],
+        self,
+        event: EventBase,
+        state_events: StateMap[EventBase],
     ) -> Union[bool, dict]:
         frozen = event.content.get("frozen", None)
         if not isinstance(frozen, bool):
@@ -474,7 +476,9 @@ class RoomAccessRules(object):
             return False
 
         current_frozen_state = (
-            state_events.get((FROZEN_STATE_TYPE, ""))
+            state_events.get(
+                (FROZEN_STATE_TYPE, ""),
+            )
         )  # type: EventBase
 
         if (
@@ -490,7 +494,9 @@ class RoomAccessRules(object):
             return True
 
         current_power_levels = (
-            state_events.get((EventTypes.PowerLevels, ""))
+            state_events.get(
+                (EventTypes.PowerLevels, ""),
+            )
         )  # type: EventBase
 
         power_levels_content = unfreeze(current_power_levels.content)

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -475,10 +475,8 @@ class RoomAccessRules(object):
         ):
             return False
 
-        current_frozen_state = (
-            state_events.get(
-                (FROZEN_STATE_TYPE, ""),
-            )
+        current_frozen_state = state_events.get(
+            (FROZEN_STATE_TYPE, ""),
         )  # type: EventBase
 
         if (
@@ -493,10 +491,8 @@ class RoomAccessRules(object):
         if not self._is_local_user(event.sender):
             return True
 
-        current_power_levels = (
-            state_events.get(
-                (EventTypes.PowerLevels, ""),
-            )
+        current_power_levels = state_events.get(
+            (EventTypes.PowerLevels, ""),
         )  # type: EventBase
 
         power_levels_content = unfreeze(current_power_levels.content)

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -442,7 +442,7 @@ class RoomAccessRules(object):
             # themselves as admin.
             current_power_levels = state_events.get((EventTypes.PowerLevels, ""))
             if current_power_levels:
-                old_content = current_power_levels.content
+                old_content = current_power_levels.content.copy()
                 old_content["users_default"] = 0
 
                 new_content = unfreeze(event.content)

--- a/synapse/third_party_rules/access_rules.py
+++ b/synapse/third_party_rules/access_rules.py
@@ -322,7 +322,7 @@ class RoomAccessRules(object):
         self,
         event: EventBase,
         state_events: StateMap[EventBase],
-    ) -> bool:
+    ) -> Union[bool, dict]:
         """Implements synapse.events.ThirdPartyEventRules.check_event_allowed.
 
         Checks the event's type and the current rule and calls the right function to
@@ -334,7 +334,8 @@ class RoomAccessRules(object):
                 State events in the room the event originated from.
 
         Returns:
-            True if the event can be allowed, False otherwise.
+            True if the event can be allowed, False otherwise, or a dictionary if the
+            event needs to be rebuilt (containing the event's new content).
         """
         if event.type == FROZEN_STATE_TYPE:
             return await self._on_frozen_state_change(event, state_events)

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -27,6 +27,7 @@ from synapse.rest import admin
 from synapse.rest.client.v1 import directory, login, room
 from synapse.third_party_rules.access_rules import (
     ACCESS_RULES_TYPE,
+    FROZEN_STATE_TYPE,
     AccessRules,
     RoomAccessRules,
 )
@@ -851,154 +852,169 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
             )
         )
 
-    def test_freezing_a_room(self):
-        """Tests that the power levels in a room change to prevent new events from
-        non-admin users when the last admin of a room leaves.
+    def test_frozen_update_power_levels(self):
+        """Tests that freezing the room with a io.element.room.frozen event produces the
+        correct changes to the power levels.
         """
+        room_id = self.create_room()
 
-        def freeze_room_with_id_and_power_levels(
-            room_id: str,
-            custom_power_levels_content: Optional[JsonDict] = None,
-        ):
-            # Invite a user to the room, they join with PL 0
-            self.helper.invite(
-                room=room_id,
-                src=self.user_id,
-                targ=self.invitee_id,
-                tok=self.tok,
-            )
-
-            # Invitee joins the room
-            self.helper.join(
-                room=room_id,
-                user=self.invitee_id,
-                tok=self.invitee_tok,
-            )
-
-            if not custom_power_levels_content:
-                # Retrieve the room's current power levels event content
-                power_levels = self.helper.get_state(
-                    room_id=room_id,
-                    event_type="m.room.power_levels",
-                    tok=self.tok,
-                )
-            else:
-                power_levels = custom_power_levels_content
-
-                # Override the room's power levels with the given power levels content
-                self.helper.send_state(
-                    room_id=room_id,
-                    event_type="m.room.power_levels",
-                    body=custom_power_levels_content,
-                    tok=self.tok,
-                )
-
-            # Ensure that the invitee leaving the room does not change the power levels
-            self.helper.leave(
-                room=room_id,
-                user=self.invitee_id,
-                tok=self.invitee_tok,
-            )
-
-            # Retrieve the new power levels of the room
-            new_power_levels = self.helper.get_state(
-                room_id=room_id,
-                event_type="m.room.power_levels",
-                tok=self.tok,
-            )
-
-            # Ensure they have not changed
-            self.assertDictEqual(power_levels, new_power_levels)
-
-            # Invite the user back again
-            self.helper.invite(
-                room=room_id,
-                src=self.user_id,
-                targ=self.invitee_id,
-                tok=self.tok,
-            )
-
-            # Invitee joins the room
-            self.helper.join(
-                room=room_id,
-                user=self.invitee_id,
-                tok=self.invitee_tok,
-            )
-
-            # Now the admin leaves the room
-            self.helper.leave(
-                room=room_id,
-                user=self.user_id,
-                tok=self.tok,
-            )
-
-            # Check the power levels again
-            new_power_levels = self.helper.get_state(
-                room_id=room_id,
-                event_type="m.room.power_levels",
-                tok=self.invitee_tok,
-            )
-
-            # Ensure that the new power levels prevent anyone but admins from sending
-            # certain events
-            self.assertEquals(new_power_levels["state_default"], 100)
-            self.assertEquals(new_power_levels["events_default"], 100)
-            self.assertEquals(new_power_levels["kick"], 100)
-            self.assertEquals(new_power_levels["invite"], 100)
-            self.assertEquals(new_power_levels["ban"], 100)
-            self.assertEquals(new_power_levels["redact"], 100)
-            self.assertDictEqual(new_power_levels["events"], {})
-            self.assertDictEqual(new_power_levels["users"], {self.user_id: 100})
-
-            # Ensure new users entering the room aren't going to immediately become admins
-            self.assertEquals(new_power_levels["users_default"], 0)
-
-        # Test that freezing a room with the default power level state event content works
-        room1 = self.create_room()
-        freeze_room_with_id_and_power_levels(room1)
-
-        # Test that freezing a room with a power level state event that is missing
-        # `state_default` and `event_default` keys behaves as expected
-        room2 = self.create_room()
-        freeze_room_with_id_and_power_levels(
-            room2,
-            {
-                "ban": 50,
-                "events": {
-                    "m.room.avatar": 50,
-                    "m.room.canonical_alias": 50,
-                    "m.room.history_visibility": 100,
-                    "m.room.name": 50,
-                    "m.room.power_levels": 100,
-                },
-                "invite": 0,
-                "kick": 50,
-                "redact": 50,
-                "users": {self.user_id: 100},
-                "users_default": 0,
-                # Explicitly remove `state_default` and `event_default` keys
-            },
+        # Set a user with a non-default PL in the room so we can make sure it's correctly
+        # removed when freezing the room, so that users can't be prevented from unfreezing
+        # the room by others.
+        power_levels = self.helper.get_state(
+            room_id=room_id,
+            event_type=EventTypes.PowerLevels,
+            tok=self.tok,
         )
 
-        # Test that freezing a room with a power level state event that is *additionally*
-        # missing `ban`, `invite`, `kick` and `redact` keys behaves as expected
-        room3 = self.create_room()
-        freeze_room_with_id_and_power_levels(
-            room3,
-            {
-                "events": {
-                    "m.room.avatar": 50,
-                    "m.room.canonical_alias": 50,
-                    "m.room.history_visibility": 100,
-                    "m.room.name": 50,
-                    "m.room.power_levels": 100,
-                },
-                "users": {self.user_id: 100},
-                "users_default": 0,
-                # Explicitly remove `state_default` and `event_default` keys
-                # Explicitly remove `ban`, `invite`, `kick` and `redact` keys
-            },
+        power_levels["users"]["@fakeuser:test"] = 50
+
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.PowerLevels,
+            body=power_levels,
+            tok=self.tok,
         )
+
+        # Mark the room as frozen.
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=FROZEN_STATE_TYPE,
+            body={"frozen": True},
+            tok=self.tok,
+        )
+
+        # Check that the right power levels event was set as a result.
+        power_levels = self.helper.get_state(
+            room_id=room_id,
+            event_type=EventTypes.PowerLevels,
+            tok=self.tok,
+        )
+
+        self.assertEqual(power_levels["users_default"], 100)
+        for user, level in power_levels["users"].items():
+            self.assertEqual(level, 100, user)
+
+        # Unfreeze the room.
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=FROZEN_STATE_TYPE,
+            body={"frozen": False},
+            tok=self.tok,
+        )
+
+        # Check that the right power levels event was set as a result.
+        power_levels = self.helper.get_state(
+            room_id=room_id,
+            event_type=EventTypes.PowerLevels,
+            tok=self.tok,
+        )
+
+        self.assertEqual(power_levels["users_default"], 0)
+        self.assertEqual(power_levels.get("users", {}).get(self.user_id, 0), 100)
+
+    def test_freezing_no_send(self):
+        """Tests that freezing a room prevents most new events from being sent into it."""
+        room_id = self.create_room()
+
+        def _send_event_and_pl_update(expected_code: int):
+            # Check whether we can send events. In a frozen state this should be
+            # forbidden.
+            self.helper.send_event(
+                room_id=room_id,
+                type=EventTypes.Message,
+                content={"msgtype": "m.text", "body": "hello world"},
+                tok=self.tok,
+                expect_code=expected_code,
+            )
+
+            # Check whether we can update the power levels in a way that would explicitly
+            # prevent someone from unfreezing the room. In a frozen state this should be
+            # forbidden.
+            power_levels = self.helper.get_state(
+                room_id=room_id,
+                event_type=EventTypes.PowerLevels,
+                tok=self.tok,
+            )
+            power_levels["users"]["@fakeuser:test"] = 50
+
+            self.helper.send_state(
+                room_id=room_id,
+                event_type=EventTypes.PowerLevels,
+                body=power_levels,
+                tok=self.tok,
+                expect_code=expected_code,
+            )
+
+        # Freeze the room and check that we can't send events into it.
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=FROZEN_STATE_TYPE,
+            body={"frozen": True},
+            tok=self.tok,
+        )
+
+        _send_event_and_pl_update(403)
+
+        # Unfreeze the room and check that we can send events into it now.
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=FROZEN_STATE_TYPE,
+            body={"frozen": False},
+            tok=self.tok,
+        )
+
+        _send_event_and_pl_update(200)
+
+    def test_auto_freeze_and_unfreeze(self):
+        room_id = self.create_room(
+            preset=RoomCreationPreset.PRIVATE_CHAT,
+            invite=[self.invitee_id]
+        )
+
+        self.helper.join(
+            room=room_id,
+            user=self.invitee_id,
+            tok=self.invitee_tok,
+        )
+
+        self.helper.leave(
+            room=room_id,
+            user=self.user_id,
+            tok=self.tok,
+        )
+
+        frozen = self.helper.get_state(
+            room_id=room_id,
+            event_type=FROZEN_STATE_TYPE,
+            tok=self.invitee_tok,
+        )
+
+        self.assertTrue(frozen["frozen"])
+
+        power_levels = self.helper.get_state(
+            room_id=room_id,
+            event_type=EventTypes.PowerLevels,
+            tok=self.invitee_tok,
+        )
+
+        self.assertEqual(power_levels["users_default"], 100)
+
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=FROZEN_STATE_TYPE,
+            body={"frozen": False},
+            tok=self.invitee_tok,
+        )
+
+        power_levels = self.helper.get_state(
+            room_id=room_id,
+            event_type=EventTypes.PowerLevels,
+            tok=self.invitee_tok,
+        )
+
+        self.assertEqual(power_levels["users_default"], 0)
+        self.assertEqual(power_levels["users"].get(self.invitee_id, 0), 100)
 
     def create_room(
         self,
@@ -1007,6 +1023,7 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
         preset=RoomCreationPreset.TRUSTED_PRIVATE_CHAT,
         initial_state=None,
         power_levels_content_override=None,
+        invite=[],
         expected_code=200,
     ):
         content = {"is_direct": direct, "preset": preset}
@@ -1024,6 +1041,9 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
 
         if power_levels_content_override:
             content["power_levels_content_override"] = power_levels_content_override
+
+        if invite:
+            content["invite"] = invite
 
         channel = self.make_request(
             "POST",

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -968,7 +968,8 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
 
     def test_auto_freeze_and_unfreeze(self):
         room_id = self.create_room(
-            preset=RoomCreationPreset.PRIVATE_CHAT, invite=[self.invitee_id],
+            preset=RoomCreationPreset.PRIVATE_CHAT,
+            invite=[self.invitee_id],
         )
 
         self.helper.join(

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -15,7 +15,6 @@
 import json
 import random
 import string
-from typing import Optional
 
 from mock import Mock
 
@@ -31,7 +30,7 @@ from synapse.third_party_rules.access_rules import (
     AccessRules,
     RoomAccessRules,
 )
-from synapse.types import JsonDict, create_requester
+from synapse.types import create_requester
 
 from tests import unittest
 

--- a/tests/rest/client/test_room_access_rules.py
+++ b/tests/rest/client/test_room_access_rules.py
@@ -968,8 +968,7 @@ class RoomAccessTestCase(unittest.HomeserverTestCase):
 
     def test_auto_freeze_and_unfreeze(self):
         room_id = self.create_room(
-            preset=RoomCreationPreset.PRIVATE_CHAT,
-            invite=[self.invitee_id]
+            preset=RoomCreationPreset.PRIVATE_CHAT, invite=[self.invitee_id],
         )
 
         self.helper.join(


### PR DESCRIPTION
A feature we currently have in the `RoomAccessRules` module is the ability to "freeze" room when the last admin has left it (https://github.com/matrix-org/synapse-dinsic/pull/59). Freezing the room means changing the room's rules in a way that prevents anyone from sending messages in the room except for leaving or taking over and unfreezing the room.

The current solution for freezing a room doesn't allow the room to be unfrozen. This is because the Matrix spec explicitly forbids a user to change their own power level, or someone else's, to a higher value than their current one. As per https://spec.matrix.org/unstable/rooms/v1/#authorization-rules:

```
10. If type is m.room.power_levels:
  [...]
  4. For each entry being added, changed or removed in both the events and users keys:
    1. If the current value is higher than the sender’s current power level, reject.
    2. If the new value is higher than the sender’s current power level, reject.
```

This means that from a Matrix perspective the room is effectively broken, because even if the power level event allows anyone to send a new `m.room.power_levels` event, whoever sends it won't be able to change its content. This means unfreezing can't work.

This means the room freezing feature needs to be changed in the following way:

* a new custom state event, `io.element.room.frozen`, is defined. Its content is `{"frozen": [...]}`, with `frozen` a boolean indicating whether the room is frozen, defaulting to `false`.
* freezing a room updates the power levels by only changing the `user_default` key to 100 (rather than sending a brand new event with every permission up'd to 100), and removing any user whose PL isn't specifically set to 100 in the `users` object (in order to not prevent them from being able to unfreeze and take over the room
* freezing a room also changes the value for `io.element.room.frozen`'s `frozen` key in the room's state, setting it to `true`
* the `RoomAccessRules` module forbids new events (except for leaving or unfreezing the room - see below for how the latter is defined) if `frozen` is `true`
* new client UI changes are introduced, triggering if `frozen` is `true` in the room's state:
  * showing the user they can't send new messages in the room
  * users aren't showed as `Admin` in the room list - setting `user_default` to 100 will have the side-effect of showing every user as admin in the room list, and I think clients should hide that to avoid any confusion around the current state of the room.

Additionally, freezing the room would set its join rules to `invite`.

This would then allow unfreezing a room by sending a new power level events that:

* gives the user unfreezing the room power level 100
* reset the `user_default` key back to 0

Here's how this PR implements it:

* when the last admin leaves the room, the `RoomAccessRules` module sends a `io.element.room.frozen` event; this in turns triggers a power levels update to be sent
* if a user sends a `io.element.room.frozen` event manually, the module updates the power levels event accordingly
* when a room is frozen any event is forbidden, except for events that allow someone to leave the room, or for events that relate to the freezing/unfreezing of the room

Future work (out of scope for this PR) include:

* promoting the user(s) with the highest PL to admin once the last admin leaves the room - and only freezing once all other users in the room have the default PL
* splitting this work out in a new module (which would require migrating the `ThirdPartyEventRules` interface to the new generic modules system first, since we'd then need to run two modules with this interface for synapse-dinsic)