### PR TITLE
Use the BaseReporter super-class for _WrappedRustReporter

### DIFF
--- a/changelog.d/105.misc
+++ b/changelog.d/105.misc
@@ -1,0 +1,1 @@
+Ensure the Rust reporter passes type checking with jaeger-client 4.7's type annotations.

--- a/changelog.d/10799.misc
+++ b/changelog.d/10799.misc
@@ -1,0 +1,1 @@
+Add a max version for the `jaeger-client` dependency for an incompatibility with the rust reporter.

--- a/changelog.d/10799.misc
+++ b/changelog.d/10799.misc
@@ -1,1 +1,0 @@
-Add a max version for the `jaeger-client` dependency for an incompatibility with the rust reporter.

--- a/synapse/logging/opentracing.py
+++ b/synapse/logging/opentracing.py
@@ -236,8 +236,17 @@ except ImportError:
 try:
     from rust_python_jaeger_reporter import Reporter
 
+    # jaeger-client 4.7.0 requires that reporters inherit from BaseReporter, which
+    # didn't exist before that version.
+    try:
+        from jaeger_client.reporter import BaseReporter
+    except ImportError:
+
+        class BaseReporter:  # type: ignore[no-redef]
+            pass
+
     @attr.s(slots=True, frozen=True)
-    class _WrappedRustReporter:
+    class _WrappedRustReporter(BaseReporter):
         """Wrap the reporter to ensure `report_span` never throws."""
 
         _reporter = attr.ib(type=Reporter, default=attr.Factory(Reporter))
@@ -382,6 +391,7 @@ def init_tracer(hs: "HomeServer"):
     # If we have the rust jaeger reporter available let's use that.
     if RustReporter:
         logger.info("Using rust_python_jaeger_reporter library")
+        assert config.sampler is not None
         tracer = config.create_tracer(RustReporter(), config.sampler)
         opentracing.set_global_tracer(tracer)
     else:


### PR DESCRIPTION
This fixes mypy errors with jaeger-client >= 4.7.0 and should be a no-op for versions before that.

Port of https://github.com/matrix-org/synapse/pull/10799