### PR TITLE
Update the `DomainRuleChecker` module to the new callback and API

### DIFF
--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -1893,15 +1893,8 @@ class FederationHandler(BaseHandler):
         if self.hs.config.block_non_admin_invites:
             raise SynapseError(403, "This server does not accept room invites")
 
-        is_published = await self.store.is_room_published(event.room_id)
-
         if not await self.spam_checker.user_may_invite(
-            event.sender,
-            event.state_key,
-            None,
-            room_id=event.room_id,
-            new_room=False,
-            published_room=is_published,
+            event.sender, event.state_key, event.room_id
         ):
             raise SynapseError(
                 403, "This user is not permitted to send invites to this server/user"

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -374,19 +374,7 @@ class RoomCreationHandler(BaseHandler):
         """
         user_id = requester.user.to_string()
 
-        if (
-            self._server_notices_mxid is not None
-            and requester.user.to_string() == self._server_notices_mxid
-        ):
-            # allow the server notices mxid to create rooms
-            is_requester_admin = True
-
-        else:
-            is_requester_admin = await self.auth.is_server_admin(requester.user)
-
-        if not is_requester_admin and not await self.spam_checker.user_may_create_room(
-            user_id, invite_list=[], third_party_invite_list=[], cloning=True
-        ):
+        if not await self.spam_checker.user_may_create_room(user_id):
             raise SynapseError(403, "You are not permitted to create rooms")
 
         creation_content: JsonDict = {
@@ -861,7 +849,6 @@ class RoomCreationHandler(BaseHandler):
                 id_server,
                 requester,
                 txn_id=None,
-                new_room=True,
                 id_access_token=id_access_token,
             )
 

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -614,15 +614,8 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
                     )
                     block_invite = True
 
-                is_published = await self.store.is_room_published(room_id)
-
                 if not await self.spam_checker.user_may_invite(
-                    requester.user.to_string(),
-                    target_id,
-                    third_party_invite=None,
-                    room_id=room_id,
-                    new_room=new_room,
-                    published_room=is_published,
+                    requester.user.to_string(), target_id, room_id
                 ):
                     logger.info("Blocking invite due to spam checker")
                     block_invite = True
@@ -1170,7 +1163,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         id_server: str,
         requester: Requester,
         txn_id: Optional[str],
-        new_room: bool = False,
         id_access_token: Optional[str] = None,
     ) -> int:
         """Invite a 3PID to a room.
@@ -1236,19 +1228,6 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         invitee = await self.identity_handler.lookup_3pid(
             id_server, medium, address, id_access_token
         )
-
-        is_published = await self.store.is_room_published(room_id)
-
-        if not await self.spam_checker.user_may_invite(
-            requester.user.to_string(),
-            invitee,
-            third_party_invite={"medium": medium, "address": address},
-            room_id=room_id,
-            new_room=new_room,
-            published_room=is_published,
-        ):
-            logger.info("Blocking invite due to spam checker")
-            raise SynapseError(403, "Invites have been disabled on this server")
 
         if invitee:
             # Note that update_membership with an action of "invite" can raise

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -734,7 +734,6 @@ class RoomMembershipRestServlet(TransactionRestServlet):
                     content["id_server"],
                     requester,
                     txn_id,
-                    new_room=False,
                     id_access_token=content.get("id_access_token"),
                 )
             except ShadowBanError:

--- a/synapse/rulecheck/domain_rule_checker.py
+++ b/synapse/rulecheck/domain_rule_checker.py
@@ -66,9 +66,6 @@ class DomainRuleChecker(object):
         self.can_only_join_rooms_with_invite = config.get(
             "can_only_join_rooms_with_invite", False
         )
-        self.can_only_create_one_to_one_rooms = config.get(
-            "can_only_create_one_to_one_rooms", False
-        )
         self.can_only_invite_during_room_creation = config.get(
             "can_only_invite_during_room_creation", False
         )

--- a/synapse/rulecheck/domain_rule_checker.py
+++ b/synapse/rulecheck/domain_rule_checker.py
@@ -144,7 +144,9 @@ class DomainRuleChecker(object):
     ) -> bool:
         """Implements the user_may_send_3pid_invite spam checker callback."""
         return await self._user_may_invite(
-            room_id=room_id, inviter_userid=inviter_userid, invitee_userid=None,
+            room_id=room_id,
+            inviter_userid=inviter_userid,
+            invitee_userid=None,
         )
 
     async def _user_may_invite(
@@ -186,7 +188,7 @@ class DomainRuleChecker(object):
             await self._api.public_room_list_manager.room_is_in_public_room_list(
                 room_id
             )
-    )
+        )
 
         if (
             published_room

--- a/synapse/rulecheck/domain_rule_checker.py
+++ b/synapse/rulecheck/domain_rule_checker.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import logging
-from typing import Dict, Optional
+from typing import Optional
 
 from synapse.api.constants import EventTypes, Membership
 from synapse.config._base import ConfigError
@@ -84,7 +84,6 @@ class DomainRuleChecker(object):
         self._api.register_spam_checker_callbacks(
             user_may_invite=self.user_may_invite,
             user_may_send_3pid_invite=self.user_may_send_3pid_invite,
-            user_may_create_room=self.user_may_create_room,
             user_may_join_room=self.user_may_join_room,
         )
 
@@ -197,24 +196,6 @@ class DomainRuleChecker(object):
             return False
 
         return invitee_domain in self.domain_mapping[inviter_domain]
-
-    async def user_may_create_room(
-        self, userid, invite_list, third_party_invite_list, cloning
-    ):
-        """Implements synapse.events.SpamChecker.user_may_create_room"""
-
-        if cloning:
-            return True
-
-        if not self.can_invite_by_third_party_id and third_party_invite_list:
-            return False
-
-        number_of_invites = len(invite_list) + len(third_party_invite_list)
-
-        if self.can_only_create_one_to_one_rooms and number_of_invites != 1:
-            return False
-
-        return True
 
     async def user_may_join_room(self, userid, room_id, is_invited):
         """Implements the user_may_join_room spam checker callback."""

--- a/synapse/rulecheck/domain_rule_checker.py
+++ b/synapse/rulecheck/domain_rule_checker.py
@@ -14,8 +14,11 @@
 # limitations under the License.
 
 import logging
+from typing import Dict, Optional
 
+from synapse.api.constants import EventTypes, Membership
 from synapse.config._base import ConfigError
+from synapse.module_api import ModuleApi
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +59,7 @@ class DomainRuleChecker(object):
     Don't forget to consider if you can invite users from your own domain.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, api: ModuleApi):
         self.domain_mapping = config["domain_mapping"] or {}
         self.default = config["default"]
 
@@ -76,36 +79,115 @@ class DomainRuleChecker(object):
             "domains_prevented_from_being_invited_to_published_rooms", []
         )
 
-    def check_event_for_spam(self, event):
-        """Implements synapse.events.SpamChecker.check_event_for_spam"""
-        return False
+        self._api = api
 
-    def user_may_invite(
+        self._api.register_spam_checker_callbacks(
+            user_may_invite=self.user_may_invite,
+            user_may_send_3pid_invite=self.user_may_send_3pid_invite,
+            user_may_create_room=self.user_may_create_room,
+            user_may_join_room=self.user_may_join_room,
+        )
+
+    async def _is_new_room(self, room_id: str) -> bool:
+        """Checks if the room provided looks new according to its state.
+
+        The module will consider a room to look new if the only m.room.member events in
+        its state are either for the room's creator (i.e. its join event) or invites sent
+        by the room's creator.
+
+        Args:
+            room_id: The ID of the room to check.
+
+        Returns:
+            Whether the room looks new.
+        """
+        state_event_filter = [
+            (EventTypes.Create, None),
+            (EventTypes.Member, None),
+        ]
+
+        events = await self._api.get_room_state(room_id, state_event_filter)
+
+        room_creator = events[(EventTypes.Create, "")].sender
+
+        for key, event in events.items():
+            if key[0] == EventTypes.Create:
+                continue
+
+            if key[1] != room_creator:
+                if (
+                    event.sender != room_creator
+                    and event.membership != Membership.INVITE
+                ):
+                    return False
+
+        return True
+
+    async def user_may_invite(
         self,
-        inviter_userid,
-        invitee_userid,
-        third_party_invite,
-        room_id,
-        new_room,
-        published_room=False,
-    ):
-        """Implements synapse.events.SpamChecker.user_may_invite"""
+        inviter_userid: str,
+        invitee_userid: str,
+        room_id: str,
+    ) -> bool:
+        """Implements the user_may_invite spam checker callback."""
+        return await self._user_may_invite(
+            room_id=room_id,
+            inviter_userid=inviter_userid,
+            invitee_userid=invitee_userid,
+        )
+
+    async def user_may_send_3pid_invite(
+        self,
+        inviter_userid: str,
+        medium: str,
+        address: str,
+        room_id: str,
+    ) -> bool:
+        """Implements the user_may_send_3pid_invite spam checker callback."""
+        return await self._user_may_invite(
+            room_id=room_id, inviter_userid=inviter_userid, invitee_userid=None,
+        )
+
+    async def _user_may_invite(
+        self,
+        room_id: str,
+        inviter_userid: str,
+        invitee_userid: Optional[str],
+    ) -> bool:
+        """Processes any incoming invite, both normal Matrix invites and 3PID ones, and
+        check if they should be allowed.
+
+        Args:
+            room_id: The ID of the room the invite is happening in.
+            inviter_userid: The MXID of the user sending the invite.
+            invitee_userid: The MXID of the user being invited, or None if this is a 3PID
+                invite (in which case no MXID exists for this user yet).
+
+        Returns:
+            Whether the invite can be allowed to go through.
+        """
+        new_room = await self._is_new_room(room_id)
+
         if self.can_only_invite_during_room_creation and not new_room:
             return False
 
-        if not self.can_invite_by_third_party_id and third_party_invite:
-            return False
-
-        # This is a third party invite (without a bound mxid), so unless we have
-        # banned all third party invites (above) we allow it.
-        if not invitee_userid:
-            return True
+        # If invitee_userid is None, then this means this is a 3PID invite (without a
+        # bound MXID), so we allow it unless the configuration mandates blocking all 3PID
+        # invites.
+        if invitee_userid is None:
+            return self.can_invite_by_third_party_id
 
         inviter_domain = self._get_domain_from_id(inviter_userid)
         invitee_domain = self._get_domain_from_id(invitee_userid)
 
         if inviter_domain not in self.domain_mapping:
             return self.default
+
+        published_room = (
+            await self._api.public_room_list_manager.room_is_in_public_room_list(
+                room_id
+            )
+    )
 
         if (
             published_room
@@ -116,7 +198,7 @@ class DomainRuleChecker(object):
 
         return invitee_domain in self.domain_mapping[inviter_domain]
 
-    def user_may_create_room(
+    async def user_may_create_room(
         self, userid, invite_list, third_party_invite_list, cloning
     ):
         """Implements synapse.events.SpamChecker.user_may_create_room"""
@@ -134,16 +216,8 @@ class DomainRuleChecker(object):
 
         return True
 
-    def user_may_create_room_alias(self, userid, room_alias):
-        """Implements synapse.events.SpamChecker.user_may_create_room_alias"""
-        return True
-
-    def user_may_publish_room(self, userid, room_id):
-        """Implements synapse.events.SpamChecker.user_may_publish_room"""
-        return True
-
-    def user_may_join_room(self, userid, room_id, is_invited):
-        """Implements synapse.events.SpamChecker.user_may_join_room"""
+    async def user_may_join_room(self, userid, room_id, is_invited):
+        """Implements the user_may_join_room spam checker callback."""
         if self.can_only_join_rooms_with_invite and not is_invited:
             return False
 
@@ -151,7 +225,9 @@ class DomainRuleChecker(object):
 
     @staticmethod
     def parse_config(config):
-        """Implements synapse.events.SpamChecker.parse_config"""
+        """Checks whether required fields exist in the provided configuration for the
+        module.
+        """
         if "default" in config:
             return config
         else:

--- a/tests/rulecheck/test_domainrulecheck.py
+++ b/tests/rulecheck/test_domainrulecheck.py
@@ -272,43 +272,6 @@ class DomainRuleCheckerRoomTestCase(unittest.HomeserverTestCase):
         channel = self._create_room(self.admin_access_token)
         assert channel.result["code"] == b"200", channel.result
 
-    def test_normal_user_cannot_create_empty_room(self):
-        channel = self._create_room(self.normal_access_token)
-        assert channel.result["code"] == b"403", channel.result
-
-    def test_normal_user_cannot_create_room_with_multiple_invites(self):
-        channel = self._create_room(
-            self.normal_access_token,
-            content={"invite": [self.other_user_id, self.admin_user_id]},
-        )
-        assert channel.result["code"] == b"403", channel.result
-
-        # Test that it correctly counts both normal and third party invites
-        channel = self._create_room(
-            self.normal_access_token,
-            content={
-                "invite": [self.other_user_id],
-                "invite_3pid": [{"medium": "email", "address": "foo@example.com"}],
-            },
-        )
-        assert channel.result["code"] == b"403", channel.result
-
-        # Test that it correctly rejects third party invites
-        channel = self._create_room(
-            self.normal_access_token,
-            content={
-                "invite": [],
-                "invite_3pid": [{"medium": "email", "address": "foo@example.com"}],
-            },
-        )
-        assert channel.result["code"] == b"403", channel.result
-
-    def test_normal_user_can_room_with_single_invites(self):
-        channel = self._create_room(
-            self.normal_access_token, content={"invite": [self.other_user_id]}
-        )
-        assert channel.result["code"] == b"200", channel.result
-
     def test_cannot_join_public_room(self):
         channel = self._create_room(self.admin_access_token)
         assert channel.result["code"] == b"200", channel.result

--- a/tests/rulecheck/test_domainrulecheck.py
+++ b/tests/rulecheck/test_domainrulecheck.py
@@ -33,6 +33,7 @@ class MockEvent:
     """Mock of an event, only implementing the fields the DomainRuleChecker module will
     use.
     """
+
     sender: str
     membership: Optional[str] = None
 
@@ -42,6 +43,7 @@ class MockPublicRoomListManager:
     """Mock of a synapse.module_api.PublicRoomListManager, only implementing the method
     the DomainRuleChecker module will use.
     """
+
     _published: bool
 
     async def room_is_in_public_room_list(self, room_id: str) -> bool:
@@ -53,6 +55,7 @@ class MockModuleApi:
     """Mock of a synapse.module_api.ModuleApi, only implementing the methods the
     DomainRuleChecker module will use.
     """
+
     _new_room: bool
     _published: bool
 
@@ -89,7 +92,12 @@ class MockModuleApi:
 # reactor to run asynchronous code.
 class DomainRuleCheckerTestCase(unittest.HomeserverTestCase):
     def _test_user_may_invite(
-        self, config, inviter, invitee, new_room, published,
+        self,
+        config,
+        inviter,
+        invitee,
+        new_room,
+        published,
     ) -> bool:
         check = DomainRuleChecker(config, MockModuleApi(new_room, published))
         return self.get_success(check.user_may_invite(inviter, invitee, "room"))
@@ -106,33 +114,53 @@ class DomainRuleCheckerTestCase(unittest.HomeserverTestCase):
 
         self.assertTrue(
             self._test_user_may_invite(
-                config, "test:source_one", "test:target_one", False, False,
+                config,
+                "test:source_one",
+                "test:target_one",
+                False,
+                False,
             ),
         )
 
         self.assertTrue(
             self._test_user_may_invite(
-                config, "test:source_one", "test:target_two", False, False,
+                config,
+                "test:source_one",
+                "test:target_two",
+                False,
+                False,
             ),
         )
 
         self.assertTrue(
             self._test_user_may_invite(
-                config, "test:source_two", "test:target_two", False, False,
+                config,
+                "test:source_two",
+                "test:target_two",
+                False,
+                False,
             ),
         )
 
         # User can invite internal user to a published room
         self.assertTrue(
             self._test_user_may_invite(
-                config, "test:source_one", "test1:target_one", False, True,
+                config,
+                "test:source_one",
+                "test1:target_one",
+                False,
+                True,
             ),
         )
 
         # User can invite external user to a non-published room
         self.assertTrue(
             self._test_user_may_invite(
-                config, "test:source_one", "test:target_two", False, False,
+                config,
+                "test:source_one",
+                "test:target_two",
+                False,
+                False,
             ),
         )
 
@@ -148,12 +176,20 @@ class DomainRuleCheckerTestCase(unittest.HomeserverTestCase):
 
         self.assertFalse(
             self._test_user_may_invite(
-                config, "test:source_one", "test:target_three", False, False,
+                config,
+                "test:source_one",
+                "test:target_three",
+                False,
+                False,
             )
         )
         self.assertFalse(
             self._test_user_may_invite(
-                config, "test:source_two", "test:target_three", False, False,
+                config,
+                "test:source_two",
+                "test:target_three",
+                False,
+                False,
             )
         )
         self.assertFalse(
@@ -185,7 +221,11 @@ class DomainRuleCheckerTestCase(unittest.HomeserverTestCase):
 
         self.assertTrue(
             self._test_user_may_invite(
-                config, "test:source_three", "test:target_one", False, False,
+                config,
+                "test:source_three",
+                "test:target_one",
+                False,
+                False,
             )
         )
 
@@ -200,7 +240,11 @@ class DomainRuleCheckerTestCase(unittest.HomeserverTestCase):
 
         self.assertFalse(
             self._test_user_may_invite(
-                config, "test:source_three", "test:target_one", False, False,
+                config,
+                "test:source_three",
+                "test:target_one",
+                False,
+                False,
             )
         )
 


### PR DESCRIPTION
Depends on https://github.com/matrix-org/synapse-dinsic/pull/110 - I've made this PR target #110's branch to make the diff more readable.

__Note to reviewer__:

Commits should be reviewable independently. Ideally the 1st commit should be its own PR, but it makes the `DomainRuleChecker` CI go red so I thought it made more sense to have it in here.

__Note to ops__:

When deploying a Synapse version including this PR, a Synapse config change is required. All that's needed should be to move the config for the `DomainRuleChecker` from the `spam_checker` section to the `modules` one of the configuration file, since I also had to port the module to the new system. So this means this bit of configuration:

```yaml
spam_checker:
    - module: synapse.rulecheck.DomainRuleChecker
      config: {...}
```

Should become:

```yaml
modules:
    - module: synapse.rulecheck.DomainRuleChecker
      config: {...}
```

Note that this PR also removes support for the now useless `can_only_create_one_to_one_rooms` config option, but Synapse or the module won't fail if this option is kept around.